### PR TITLE
contrib/client-demo:  Displaying http response codes for both API responses

### DIFF
--- a/contrib/client-demo/js/wasabiTest.js
+++ b/contrib/client-demo/js/wasabiTest.js
@@ -43,8 +43,8 @@ $(document)
 																+ expLabel
 																+ "/users/"
 																+ userID,
-														function(data) {
-															response = $.param(data);
+														function(data, textStatus, jqXHR) {
+															response = jqXHR.status + " " + jqXHR.statusText + "<br/>" + $.param(data);
 															bucket = data.assignment;
                                                             $('#responseFromService').html(response);
 														});
@@ -66,10 +66,12 @@ $(document).ready(
 									type : 'post',
 									data : '{"events":[{"name":"BuyClicked"}]}',
 									contentType : "application/json",
-									success: function(xml, textStatus, xhr) {
-                                            console.log(xhr.status);
-                                            $('#responseFromService2').html("HTTP RESPONSE CODE: " + xhr.status);
-                                    }
+									complete: function(xhr, textStatus) {
+										  var msg = xhr.status + " " + xhr.statusText;
+                      console.log(msg);
+                      $('#responseFromService2').html(msg);
+                  },
+
 								});
 
 							});
@@ -107,7 +109,7 @@ var SwitchPages = function(){
 
 		break;
 	}
-	
+
 }
 
 // NEXT-Button. Switch between the views


### PR DESCRIPTION
No associated issue.  Please advise if an issue should be created.

- Adding the http response codes to the API response
- For the acton API, required using "complete" instead of "success" ajax handler because the response content-type was causing jQuery to try and parse the empty body.

Consider creating an issue to update the action API to not include the content-type (which jQuery uses to try and parse the response in to JSON)

