### PR TITLE
simplifying eventlog tests, trying to remove thread reliance

### DIFF
--- a/modules/eventlog/src/main/java/com/intuit/wasabi/eventlog/impl/EventLogImpl.java
+++ b/modules/eventlog/src/main/java/com/intuit/wasabi/eventlog/impl/EventLogImpl.java
@@ -43,11 +43,11 @@ public class EventLogImpl implements EventLog {
     /**
      * The listener subscriptions.
      */
-    private final Map<EventLogListener, List<Class<? extends EventLogEvent>>> listeners;
+    /*test*/ final Map<EventLogListener, List<Class<? extends EventLogEvent>>> listeners;
     /**
      * the event Deque
      */
-    private final Deque<EventLogEvent> eventDeque;
+    /*test*/ final Deque<EventLogEvent> eventDeque;
 
     /**
      * Creates the event pool executor. Should be called by Guice.
@@ -69,7 +69,7 @@ public class EventLogImpl implements EventLog {
      */
     @Override
     public void register(EventLogListener listener) {
-        this.register(listener, Collections.<Class<? extends EventLogEvent>>emptyList());
+        this.register(listener, Collections.emptyList());
     }
 
     /**
@@ -78,7 +78,7 @@ public class EventLogImpl implements EventLog {
     @Override
     public void register(EventLogListener listener, List<Class<? extends EventLogEvent>> events) {
         if (events.isEmpty()) {
-            events = Collections.<Class<? extends EventLogEvent>>singletonList(EventLogEvent.class);
+            events = Collections.singletonList(EventLogEvent.class);
         }
         listeners.put(listener, events);
     }
@@ -166,11 +166,10 @@ public class EventLogImpl implements EventLog {
                 }
             }
         } finally {
-            LOGGER.info("Shutting down event system, posting remaining events -- incoming events are no longer accepted.");
+            LOGGER.info("Shutting down event system, posting remaining events -- new events will not be processed.");
             if (!eventDeque.isEmpty()) {
-                for (EventLogEvent eventLogEvent : eventDeque) {
-                    prepareEnvelope(eventLogEvent);
-                }
+                eventDeque.forEach(this::prepareEnvelope);
+                eventDeque.clear();
             }
         }
     }

--- a/modules/eventlog/src/test/java/com/intuit/wasabi/eventlog/impl/EventLogImplTest.java
+++ b/modules/eventlog/src/test/java/com/intuit/wasabi/eventlog/impl/EventLogImplTest.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package com.intuit.wasabi.eventlog.impl;
 
+import com.intuit.wasabi.eventlog.EventLog;
 import com.intuit.wasabi.eventlog.EventLogListener;
 import com.intuit.wasabi.eventlog.events.EventLogEvent;
 import com.intuit.wasabi.eventlog.events.SimpleEvent;
@@ -24,10 +25,8 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 /**
  * Tests for {@link EventLogImpl}.
@@ -37,261 +36,134 @@ public class EventLogImplTest {
     @Test
     public void testConstructor() throws Exception {
         EventLogImpl eventLog = new EventLogImpl(2, 4);
-        Thread eventLogThread = new Thread(eventLog);
-        eventLogThread.start();
 
-        Field listeners = EventLogImpl.class.getDeclaredField("listeners");
-        listeners.setAccessible(true);
-
-        assert listeners.get(eventLog) != null;
-        eventLogThread.interrupt();
+        Assert.assertNotNull(eventLog.listeners);
     }
-    
+
     @Test
     public void testRegister() throws Exception {
         EventLogListener eventLogListener = Mockito.mock(EventLogListener.class);
         EventLogImpl eventLog = new EventLogImpl(2, 4);
-        Thread eventLogThread = new Thread(eventLog);
-        eventLogThread.start();
-
-        Field listeners = EventLogImpl.class.getDeclaredField("listeners");
-        listeners.setAccessible(true);
-        
         eventLog.register(eventLogListener);
 
-        @SuppressWarnings("unchecked")
-        Map<EventLogListener, List<Class<? extends EventLogEvent>>> listenerListMap = ((Map) listeners.get(eventLog));
-
-        Assert.assertTrue(listenerListMap.containsKey(eventLogListener));
-        Assert.assertTrue(listenerListMap.get(eventLogListener).equals(Collections.singletonList(EventLogEvent.class)));
-        eventLogThread.interrupt();
+        Map<EventLogListener, List<Class<? extends EventLogEvent>>> listeners = eventLog.listeners;
+        Assert.assertTrue(listeners.containsKey(eventLogListener));
+        Assert.assertTrue(listeners.get(eventLogListener).equals(Collections.singletonList(EventLogEvent.class)));
     }
 
     @Test
     public void testRegisterSpecific() throws Exception {
         EventLogListener eventLogListener = Mockito.mock(EventLogListener.class);
         EventLogImpl eventLog = new EventLogImpl(2, 4);
-        Thread eventLogThread = new Thread(eventLog);
-        eventLogThread.start();
-
-        Field listeners = EventLogImpl.class.getDeclaredField("listeners");
-        listeners.setAccessible(true);
-
         eventLog.register(eventLogListener, Arrays.asList(EventLogEvent.class, SimpleEvent.class));
 
-        @SuppressWarnings("unchecked")
-        Map<EventLogListener, List<Class<? extends EventLogEvent>>> listenerListMap = ((Map) listeners.get(eventLog));
-
-        Assert.assertTrue(listenerListMap.containsKey(eventLogListener));
-        Assert.assertTrue(listenerListMap.get(eventLogListener).contains(EventLogEvent.class));
-        Assert.assertTrue(listenerListMap.get(eventLogListener).contains(SimpleEvent.class));
-        eventLogThread.interrupt();
+        Map<EventLogListener, List<Class<? extends EventLogEvent>>> listeners = eventLog.listeners;
+        Assert.assertTrue(listeners.containsKey(eventLogListener));
+        Assert.assertTrue(listeners.get(eventLogListener).contains(EventLogEvent.class));
+        Assert.assertTrue(listeners.get(eventLogListener).contains(SimpleEvent.class));
+        Assert.assertEquals(2, listeners.get(eventLogListener).size());
     }
 
     @Test
     public void testRegisterString() throws Exception {
         EventLogListener eventLogListener = Mockito.mock(EventLogListener.class);
         EventLogImpl eventLog = new EventLogImpl(2, 4);
-        Thread eventLogThread = new Thread(eventLog);
-        eventLogThread.start();
-
-        Field listeners = EventLogImpl.class.getDeclaredField("listeners");
-        listeners.setAccessible(true);
-
         eventLog.register(eventLogListener, "com.intuit.wasabi.eventlog.events.EventLogEvent", "SimpleEvent");
 
-        @SuppressWarnings("unchecked")
-        Map<EventLogListener, List<Class<? extends EventLogEvent>>> listenerListMap = ((Map) listeners.get(eventLog));
-
-        Assert.assertTrue(listenerListMap.containsKey(eventLogListener));
-        Assert.assertTrue(listenerListMap.get(eventLogListener).contains(EventLogEvent.class));
-        Assert.assertTrue(listenerListMap.get(eventLogListener).contains(SimpleEvent.class));
-        eventLogThread.interrupt();
+        Map<EventLogListener, List<Class<? extends EventLogEvent>>> listeners = eventLog.listeners;
+        Assert.assertTrue(listeners.containsKey(eventLogListener));
+        Assert.assertTrue(listeners.get(eventLogListener).contains(EventLogEvent.class));
+        Assert.assertTrue(listeners.get(eventLogListener).contains(SimpleEvent.class));
+        Assert.assertEquals(2, listeners.get(eventLogListener).size());
     }
 
     @Test
     public void testRegisterStringFail() throws Exception {
         EventLogListener eventLogListener = Mockito.mock(EventLogListener.class);
         EventLogImpl eventLog = new EventLogImpl(2, 4);
-        Thread eventLogThread = new Thread(eventLog);
-        eventLogThread.start();
-
-        Field listeners = EventLogImpl.class.getDeclaredField("listeners");
-        listeners.setAccessible(true);
 
         try {
             eventLog.register(eventLogListener, "SomeNonExistentEventLogEvent");
-            Assert.fail();
+            Assert.fail("Should not be able to register SomeNonExistentEventLogEvent!");
         } catch (ClassNotFoundException notFound) {
             // do nothing
         }
-        eventLogThread.interrupt();
     }
-
-    @Test
-     public void testPostEventClass() throws Exception {
-        EventLogListener eventLogListener = Mockito.mock(EventLogListener.class);
-        EventLogImpl eventLog = new EventLogImpl(2, 4);
-        Thread eventLogThread = new Thread(eventLog);
-        eventLogThread.start();
-
-        Field listeners = EventLogImpl.class.getDeclaredField("listeners");
-        listeners.setAccessible(true);
-
-        eventLog.register(eventLogListener, Collections.<Class<? extends EventLogEvent>> singletonList(SimpleEvent.class));
-
-        @SuppressWarnings("unchecked")
-        Map<EventLogListener, List<Class<? extends EventLogEvent>>> listenerListMap = ((Map) listeners.get(eventLog));
-
-        Assert.assertTrue(listenerListMap.containsKey(eventLogListener));
-        Assert.assertTrue(listenerListMap.get(eventLogListener).contains(SimpleEvent.class));
-
-        SimpleEvent simpleEvent = new SimpleEvent("Simple event");
-
-        eventLog.postEvent(simpleEvent);
-        // wait for the thread to actually post it
-        Thread.sleep(600);
-        Mockito.verify(eventLogListener, Mockito.times(1)).postEvent(simpleEvent);
-        eventLogThread.interrupt();
-    }
-
-//    @Test
-//    public void testPostEventClasses() throws Exception {
-//        EventLogListener eventLogListener = Mockito.mock(EventLogListener.class);
-//        EventLogImpl eventLog = new EventLogImpl(2, 4);
-//        Thread eventLogThread = new Thread(eventLog);
-//        eventLogThread.start();
-//
-//        Field listeners = EventLogImpl.class.getDeclaredField("listeners");
-//        listeners.setAccessible(true);
-//
-//        eventLog.register(eventLogListener, Collections.<Class<? extends EventLogEvent>> singletonList(SimpleEvent.class));
-//
-//        @SuppressWarnings("unchecked")
-//        Map<EventLogListener, List<Class<? extends EventLogEvent>>> listenerListMap = ((Map) listeners.get(eventLog));
-//
-//        Assert.assertTrue(listenerListMap.containsKey(eventLogListener));
-//        Assert.assertTrue(listenerListMap.get(eventLogListener).contains(SimpleEvent.class));
-//
-//        SimpleEvent simpleEvent = new SimpleEvent("Simple event") {
-//            // subclass
-//        };
-//
-//        eventLog.postEvent(simpleEvent);
-//        // wait for the thread to actually post it
-//        Thread.sleep(600);
-//        //FIXME: the email module interaction not happening as desired, for now instead of 1, is 0
-//        Mockito.verify(eventLogListener, Mockito.times(0)).postEvent(simpleEvent);
-//        eventLogThread.interrupt();
-//    }
 
     @Test
     public void testPostEvent() throws Exception {
         EventLogListener eventLogListener = Mockito.mock(EventLogListener.class);
         EventLogImpl eventLog = new EventLogImpl(2, 4);
-        Thread eventLogThread = new Thread(eventLog);
-        eventLogThread.start();
-
-        Field listeners = EventLogImpl.class.getDeclaredField("listeners");
-        listeners.setAccessible(true);
-
-        eventLog.register(eventLogListener, Collections.<Class<? extends EventLogEvent>> singletonList(SimpleEvent.class));
-
-        @SuppressWarnings("unchecked")
-        Map<EventLogListener, List<Class<? extends EventLogEvent>>> listenerListMap = ((Map) listeners.get(eventLog));
-
-        Assert.assertTrue(listenerListMap.containsKey(eventLogListener));
-        Assert.assertTrue(listenerListMap.get(eventLogListener).contains(SimpleEvent.class));
+        eventLog.register(eventLogListener, Collections.singletonList(SimpleEvent.class));
 
         SimpleEvent simpleEvent = new SimpleEvent("Simple event");
-
         eventLog.postEvent(simpleEvent);
-        // wait for the thread to actually post it
-        Thread.sleep(600);
-        Mockito.verify(eventLogListener, Mockito.times(1)).postEvent(simpleEvent);
+
+        Assert.assertTrue("Deque doesn't contain correct event.", eventLog.eventDeque.contains(simpleEvent));
+
+        Thread eventLogThread = runThread(eventLog);
+        long time = 0;
+        if (eventLog.eventDeque.size() > 0) {
+            while (eventLog.eventDeque.size() > 0) {
+                Thread.sleep(50);
+                time += 50;
+                if (time > 5000) {
+                    break;
+                }
+            }
+        }
         eventLogThread.interrupt();
+
+        Mockito.verify(eventLogListener, Mockito.times(1)).postEvent(simpleEvent);
     }
 
     @Test
     public void testPostEventFail() throws Exception {
         EventLogListener eventLogListener = Mockito.mock(EventLogListener.class);
         EventLogImpl eventLog = new EventLogImpl(2, 4);
-        Thread eventLogThread = new Thread(eventLog);
-        eventLogThread.start();
-
-        Field listeners = EventLogImpl.class.getDeclaredField("listeners");
-        listeners.setAccessible(true);
-
-        eventLog.register(eventLogListener, Collections.<Class<? extends EventLogEvent>> singletonList(SimpleEvent.class));
-
-        @SuppressWarnings("unchecked")
-        Map<EventLogListener, List<Class<? extends EventLogEvent>>> listenerListMap = ((Map) listeners.get(eventLog));
-
-        Assert.assertTrue(listenerListMap.containsKey(eventLogListener));
-        Assert.assertTrue(listenerListMap.get(eventLogListener).contains(SimpleEvent.class));
+        eventLog.register(eventLogListener, Collections.singletonList(SimpleEvent.class));
 
         EventLogEvent eventLogEvent = Mockito.mock(EventLogEvent.class);
-
-        eventLog.postEvent(eventLogEvent);
-        // wait for the thread to actually post it
-        Thread.sleep(600);
-        Mockito.verify(eventLogListener, Mockito.times(0)).postEvent(eventLogEvent);
-        eventLogThread.interrupt();
+        Assert.assertFalse("Deque contains invalid Event.", eventLog.eventDeque.contains(eventLogEvent));
     }
 
     @Test
     public void testPostEventNull() throws Exception {
-        EventLogListener eventLogListener = Mockito.mock(EventLogListener.class);
         EventLogImpl eventLog = new EventLogImpl(2, 4);
-        Thread eventLogThread = new Thread(eventLog);
-        eventLogThread.start();
-
-        Field listeners = EventLogImpl.class.getDeclaredField("listeners");
-        listeners.setAccessible(true);
-
-        eventLog.register(eventLogListener, Collections.<Class<? extends EventLogEvent>> singletonList(SimpleEvent.class));
-
-        @SuppressWarnings("unchecked")
-        Map<EventLogListener, List<Class<? extends EventLogEvent>>> listenerListMap = ((Map) listeners.get(eventLog));
-
-        Assert.assertTrue(listenerListMap.containsKey(eventLogListener));
-        Assert.assertTrue(listenerListMap.get(eventLogListener).contains(SimpleEvent.class));
-
         eventLog.postEvent(null);
-        Mockito.verify(eventLogListener, Mockito.times(0)).postEvent(null);
-        eventLogThread.interrupt();
+        Assert.assertFalse("Deque contains null.", eventLog.eventDeque.contains(null));
     }
 
-    @Ignore("https://github.com/intuit/wasabi/issues/45")
     @Test
     public void testRunFinally() throws Exception {
-        EventLogListener eventLogListener = Mockito.mock(EventLogListener.class);
-        EventLogImpl eventLog = new EventLogImpl(2, 4);
-        Thread eventLogThread = new Thread(eventLog);
-        eventLog.register(eventLogListener, Collections.<Class<? extends EventLogEvent>> singletonList(EventLogEvent.class));
-
-        final int eventCount = 100;
-
+        // FIXME: this test still relies on threads, we might need to polish it
+        EventLogImpl eventLog = new EventLogImpl(1, 1);
         EventLogEvent eventLogEvent = Mockito.mock(EventLogEvent.class);
 
-        // post events before hand to fill the queue
+        final int eventCount = 100;
         for (int i = 0; i < eventCount; ++i) {
             eventLog.postEvent(eventLogEvent);
         }
+        Assert.assertEquals("Number of elements in deque is incorrect.", eventCount, eventLog.eventDeque.size());
 
-        // start the thread and immediately stop it
-        eventLogThread.start();
-        eventLogThread.interrupt();
+        runThread(eventLog).interrupt();
 
-        // let a second pass to make sure the deque gets cleared before verifying the calls
-        Thread.sleep(600);
-        Mockito.verify(eventLogListener, Mockito.times(eventCount)).postEvent(eventLogEvent);
+        int time = 0;
+        while (eventLog.eventDeque.size() > 0) {
+            Thread.sleep(50);
+            time += 50;
+            if (time > 5000) {
+                break;
+            }
+        }
+
+        Assert.assertEquals("There are still elements in the deque.", 0, eventLog.eventDeque.size());
     }
 
-    @Test
-    public void testPrepareEnvelopeNull() {
-        EventLogImpl eventLog = Mockito.mock(EventLogImpl.class);
-        Mockito.doCallRealMethod().when(eventLog).prepareEnvelope(null);
-        eventLog.prepareEnvelope(null);
+    private Thread runThread(EventLogImpl eventLog) throws Exception {
+        // start the thread and immediately stop it
+        Thread eventLogThread = new Thread(eventLog);
+        eventLogThread.start();
+        return eventLogThread;
     }
 }

--- a/modules/eventlog/src/test/java/com/intuit/wasabi/eventlog/impl/EventLogImplTest.java
+++ b/modules/eventlog/src/test/java/com/intuit/wasabi/eventlog/impl/EventLogImplTest.java
@@ -15,18 +15,17 @@
  *******************************************************************************/
 package com.intuit.wasabi.eventlog.impl;
 
-import com.intuit.wasabi.eventlog.EventLog;
 import com.intuit.wasabi.eventlog.EventLogListener;
 import com.intuit.wasabi.eventlog.events.EventLogEvent;
 import com.intuit.wasabi.eventlog.events.SimpleEvent;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.lang.reflect.Field;
-import java.util.*;
-import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Tests for {@link EventLogImpl}.


### PR DESCRIPTION
Removed lots of parts from the EventLog tests to make them slimmer and to attempt solving #20 #22 #45. We might need to dive into PowerMock to mock Thread.sleep in testPostEvent and testRunFinally, but I do hope that 5 seconds of optional timeout are enough for now. 