### PR TITLE
Making scripts bash v3 & v4 compatible

### DIFF
--- a/bin/container.sh
+++ b/bin/container.sh
@@ -228,6 +228,19 @@ EOF
   docker ps 2>/dev/null
 }
 
+exec_commands_simple() {
+        prefix=$1
+        commands=$(echo $2 | cut -d ':' -f 2)
+        (IFS=','; for command in ${commands}; do ${prefix}${command}; done)
+}
+
+exec_commands_project() {
+        prefix=$1
+        commands=$(echo $2 | cut -d ':' -f 2)
+	(IFS=','; for command in ${commands}; do ${prefix} ${project}-${command/${project}/main}; done)
+}
+
+
 optspec=":f:p:v:s:h-:"
 
 while getopts "${optspec}" opt; do
@@ -256,19 +269,15 @@ sleep=${sleep:=${sleep_default}}
 
 for command in ${@:$OPTIND}; do
   case "${command}" in
-    start) command="start:cassandra,mysql,wasabi";&
-    start:*) commands=$(echo ${command} | cut -d':' -f 2)
-      (IFS=','; for command in ${commands}; do start_${command}; done);;
-    stop) command="stop:main,cassandra,mysql";&
-    stop:*) commands=$(echo ${command} | cut -d':' -f 2)
-      (IFS=','; for command in ${commands}; do stop_container ${project}-${command/${project}/main}; done);;
-    console) command="console:cassandra,mysql";&
-    console:*) commands=$(echo ${command} | cut -d':' -f 2)
-      (IFS=','; for command in ${commands}; do console_${command}; done);;
+    start) exec_commands_simple start_ cassandra,mysql,wasabi;;
+    start:*) exec_commands_simple start_ ${command};;
+    stop) exec_commands_project stop_container main,cassandra,mysql;;
+    stop:*) exec_commands_project stop_container ${command};;
+    console) exec_commands_simple console_ cassandra,mysql;;
+    console:*) exec_commands_simple console_ ${command};;
     status) status;;
-    remove) command="remove:wasabi,cassandra,mysql";&
-    remove:*) commands=$(echo ${command} | cut -d':' -f 2)
-      (IFS=','; for command in ${commands}; do remove_container ${project}-${command/${project}/main}; done);;
+    remove) exec_commands_project remove_container wasabi,cassandra,mysql;;
+    remove:*) exec_commands_project remove_container ${command};;
     "") usage "unknown command: ${command}" 1;;
     *) usage "unknown command: ${command}" 1;;
   esac

--- a/bin/container.sh
+++ b/bin/container.sh
@@ -229,15 +229,15 @@ EOF
 }
 
 exec_commands_simple() {
-        prefix=$1
-        commands=$(echo $2 | cut -d ':' -f 2)
-        (IFS=','; for command in ${commands}; do ${prefix}${command}; done)
+  prefix=$1
+  commands=$(echo $2 | cut -d ':' -f 2)
+  (IFS=','; for command in ${commands}; do ${prefix}${command}; done)
 }
 
 exec_commands_project() {
-        prefix=$1
-        commands=$(echo $2 | cut -d ':' -f 2)
-	(IFS=','; for command in ${commands}; do ${prefix} ${project}-${command/${project}/main}; done)
+  prefix=$1
+  commands=$(echo $2 | cut -d ':' -f 2)
+  (IFS=','; for command in ${commands}; do ${prefix} ${project}-${command/${project}/main}; done)
 }
 
 

--- a/bin/wasabi.sh
+++ b/bin/wasabi.sh
@@ -310,10 +310,15 @@ remove() {
   ./bin/container.sh remove${1:+:$1}
 }
 
+unit_test() {
+  command=$1
+  mvn "-Dtest=com.intuit.wasabi.${command/-/}.**" test -pl modules/${command} --also-make -DfailIfNoTests=false -q
+}
+
 exec_commands() {
-        prefix=$1
-        commands=$(echo $2 | cut -d ':' -f 2)
-        (IFS=','; for command in ${commands}; do ${prefix} ${command}; done)
+  prefix=$1
+  commands=$(echo $2 | cut -d ':' -f 2)
+  (IFS=','; for command in ${commands}; do ${prefix} ${command}; done)
 }
 
 optspec=":b:e:f:p:v:s:h-:"
@@ -355,8 +360,7 @@ for command in ${@:$OPTIND}; do
     clean) clean;;
     start) exec_commands start "cassandra,mysql,wasabi";;
     start:*) exec_commands start ${command};;
-    test:*) commands=$(echo ${command} | cut -d ':' -f 2)
-      (IFS=','; for command in ${commands}; do mvn "-Dtest=com.intuit.wasabi.${command/-/}.**" test -pl modules/${command} --also-make -DfailIfNoTests=false -q ; done);;
+    test:*) exec_commands unit_test ${command};;
     test) test_api;;
     stop) exec_commands stop "wasabi,mysql,cassandra";;
     stop:*) exec_commands stop ${command};;

--- a/bin/wasabi.sh
+++ b/bin/wasabi.sh
@@ -310,6 +310,12 @@ remove() {
   ./bin/container.sh remove${1:+:$1}
 }
 
+exec_commands() {
+        prefix=$1
+        commands=$(echo $2 | cut -d ':' -f 2)
+        (IFS=','; for command in ${commands}; do ${prefix} ${command}; done)
+}
+
 optspec=":b:e:f:p:v:s:h-:"
 
 while getopts "${optspec}" opt; do
@@ -347,26 +353,21 @@ for command in ${@:$OPTIND}; do
     bootstrap) bootstrap;;
     build) build true;;
     clean) clean;;
-    start) command="start:cassandra,mysql,wasabi";&
-    start:*) commands=$(echo ${command} | cut -d ':' -f 2)
-      (IFS=','; for command in ${commands}; do start ${command}; done);;
+    start) exec_commands start "cassandra,mysql,wasabi";;
+    start:*) exec_commands start ${command};;
     test:*) commands=$(echo ${command} | cut -d ':' -f 2)
       (IFS=','; for command in ${commands}; do mvn "-Dtest=com.intuit.wasabi.${command/-/}.**" test -pl modules/${command} --also-make -DfailIfNoTests=false -q ; done);;
     test) test_api;;
-    stop) command="stop:wasabi,mysql,cassandra";&
-    stop:*) commands=$(echo ${command} | cut -d ':' -f 2)
-      (IFS=','; for command in ${commands}; do stop ${command}; done);;
-    resource) command="resource:ui,api,doc,casssandra,mysql";&
-    resource:*) commands=$(echo ${command} | cut -d ':' -f 2)
-      (IFS=','; for command in ${commands}; do resource ${command}; done);;
+    stop) exec_commands stop "wasabi,mysql,cassandra";;
+    stop:*) exec_commands stop ${command};;
+    resource) exec_commands resource "ui,api,doc,cassandra,mysql";;
+    resource:*) exec_commands resource ${command};;
     status) status;;
-    remove) command="remove:wasabi,cassandra,mysql";&
-    remove:*) commands=$(echo ${command} | cut -d ':' -f 2)
-      (IFS=','; for command in ${commands}; do remove ${command}; done);;
+    remove) exec_commands remove "wasabi,cassandra,mysql";;
+    remove:*) exec_commands remove ${command};;
     package) package;;
     release) release;;
-    release:*) commands=$(echo ${command} | cut -d ':' -f 2)
-      (IFS=','; for command in ${commands}; do release ${command}; done);;
+    release:*) exec_commands release ${command};;
     "") usage "unknown command: ${command}" 1;;
     *) usage "unknown command: ${command}" 1;;
   esac


### PR DESCRIPTION
To make bash v3 compatible, removed all occurrences of “;&” from the
CASE statements.

To reduce code duplicity created simple utility functions to parse & execute
commands.

I have done testing with both bash 4 and bash 3:

Testing steps/commands:
./bin/wasabi.sh start
./bin/wasabi.sh stop:wasabi
./bin/wasabi.sh stop:cassandra
./bin/wasabi.sh stop:mysql
./bin/wasabi.sh stop
./bin/wasabi.sh start:cassandra
./bin/wasabi.sh start:mysql
./bin/wasabi.sh start:wasabi
./bin/wasabi.sh resource:ui
./bin/wasabi.sh resource:api
./bin/wasabi.sh resource:doc
./bin/wasabi.sh resource:cassandra
./bin/wasabi.sh resource:mysql
./bin/wasabi.sh resource
./bin/wasabi.sh stop
./bin/wasabi.sh remove:wasabi
./bin/wasabi.sh remove:cassandra
./bin/wasabi.sh remove:mysql
./bin/wasabi.sh remove
./bin/wasabi.sh release:start
./bin/wasabi.sh release:finish
./bin/wasabi.sh release


@jwtodd , @shoeffner, @iizrailevsky could you please review and suggest in case of any changes… 