### PR TITLE
Fix logback issue

### DIFF
--- a/modules/main/src/main/resources/logback-access.xml
+++ b/modules/main/src/main/resources/logback-access.xml
@@ -22,9 +22,14 @@
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG}.access.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>%d{yyyy-MM-dd}.log.zip</fileNamePattern>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>${LOG}.%i.log.zip</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>6</maxIndex>
         </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+           <maxFileSize>500MB</maxFileSize>
+        </triggeringPolicy>
         <encoder>
             <pattern>combined</pattern>
         </encoder>

--- a/modules/main/src/main/resources/logback.xml
+++ b/modules/main/src/main/resources/logback.xml
@@ -30,15 +30,14 @@
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG}.log</file>
-        <append>true</append>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>%d{yyyy-MM-dd}.%i.log.zip</fileNamePattern>
-            <maxHistory>30</maxHistory>
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>100MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>${LOG}.%i.log.zip</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>6</maxIndex>
         </rollingPolicy>
-
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+           <maxFileSize>500MB</maxFileSize>
+        </triggeringPolicy>
         <encoder>
             <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
         </encoder>


### PR DESCRIPTION
1) fileNamePattern was missing "${LOG}." and this created lots of *.tmp files and was causing disk to get full.
2) Replaced rollingPolicy with ch.qos.logback.core.rolling.FixedWindowRollingPolicy. This will prevent run out of disk space if load is really high for peak season.

@jwtodd 