### PR TITLE
Fix to problem with displaying assignment counts when only one bucket

### DIFF
--- a/modules/ui/app/scripts/services/UtilitiesFactory.js
+++ b/modules/ui/app/scripts/services/UtilitiesFactory.js
@@ -582,18 +582,18 @@ angular.module('wasabi.services').factory('UtilitiesFactory', ['Session', '$stat
 
                     // We need the buckets to be an array so we can sort it.
                     theBuckets.push(experiment.statistics.buckets[bucketLabel]);
-                }
-
-                experiment.statistics.sortedBuckets = $filter('orderBy')(theBuckets, function(bucket) {
                     // Find the matching bucket in the experiment bucket list, which has the count from
                     // the application statistics call on it, and put the count in the sorted bucket so
                     // it will be available for the list.
                     for (var i = 0; i < experiment.buckets.length; i++) {
-                        if (experiment.buckets[i].label === bucket.label) {
-                            bucket.count = experiment.buckets[i].count;
+                        if (experiment.buckets[i].label === bucketLabel) {
+                            experiment.statistics.buckets[bucketLabel].count = experiment.buckets[i].count;
                         }
                     }
 
+                }
+
+                experiment.statistics.sortedBuckets = $filter('orderBy')(theBuckets, function(bucket) {
                     return that.actionRate(bucket.label, experiment.statistics.buckets);
                 }, true);
 


### PR DESCRIPTION
Initial changes to fix problem that if there is only one bucket, we weren't getting the count in the list. Fix is that the code to get the count into the objects used for creating the list was in a kind of loop that isn't run when there's only one.  Moved the code to a loop that is done even when there is only one.