### PR TITLE
mod: rm cobertura

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -381,23 +381,6 @@ http://www.w3.org/2001/XMLSchema-instance">
                     </execution>
                 </executions>
             </plugin>
-            <!--
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <format>xml</format>
-                    <maxmem>256m</maxmem>
-                    <aggregate>true</aggregate>
-                    <instrumentation>
-                        <excludes>
-                            <exclude>com/intuit/wasabi/tests/**/*.class</exclude>
-                        </excludes>
-                    </instrumentation>
-                </configuration>
-            </plugin>
-            -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -381,6 +381,7 @@ http://www.w3.org/2001/XMLSchema-instance">
                     </execution>
                 </executions>
             </plugin>
+            <!--
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
@@ -396,6 +397,7 @@ http://www.w3.org/2001/XMLSchema-instance">
                     </instrumentation>
                 </configuration>
             </plugin>
+            -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>


### PR DESCRIPTION
issue: travis build fails/red
cause: likely cobertura-plugin, uneeded [ see: https://github.com/cobertura/cobertura/issues/176 ]
action: remove cobertura plugin from [ws]/pom.xml [ see: https://travis-ci.org/intuit/wasabi/jobs/168537674 ]
verify: local build, internal build

cc: @iizrailevsky 