### PR TITLE
Changes to fix some problems in the Traffic Management plugin where y…

### DIFF
--- a/contrib/traffic-management-plugins/plugins/traffic-analysis/ctrl.js
+++ b/contrib/traffic-management-plugins/plugins/traffic-analysis/ctrl.js
@@ -102,6 +102,11 @@ angular.module('wasabi.controllers').
                     endTime = endTimeObj.format('MM/DD/YYYY'),
                     timeZone = startTimeObj.format('ZZ');
 
+                if (endTimeObj.isBefore(startTimeObj)) {
+                    UtilitiesFactory.displayPageError('Dates Out of Order', 'The Start Date must be before the End Date.');
+                    return;
+                }
+
                 $scope.relatedExperiments = [];
                 $scope.meDoneNames = [];
                 $scope.mutualExclusions = {};


### PR DESCRIPTION
…ou could enter negative target percentages, sometimes they were generated, and when there were errors, we weren’t disabling the Save button.  Fixed a problem in the Traffic Analysis plugin where you could enter the start and end dates such that they weren’t in order (e.g., start date after end date).