### PR TITLE
Externalize installing modules so it can be overridden by child class.

### DIFF
--- a/modules/api/src/main/java/com/intuit/wasabi/api/ApiModule.java
+++ b/modules/api/src/main/java/com/intuit/wasabi/api/ApiModule.java
@@ -55,22 +55,8 @@ public class ApiModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        LOGGER.debug("installing module: {}", ApiModule.class.getSimpleName());
-        //these modules are either free of other dependencies or they are required by later modules
-        install(new com.intuit.autumn.api.ApiModule());
-        install(new UserDirectoryModule());
-        install(new DatabaseExperimentRepositoryModule());
-        install(new DatabaseModule());
-        install(new JacksonModule());
-        install(new AuditLogModule());
-        install(new AuthorizationModule());
 
-        install(new EmailModule());
-        install(new EventsModule());
-        install(new ExperimentsModule());
-        install(new FeedbackModule());
-        install(new AnalyticsModule());
-
+        installModules();
 
         Properties properties = create(PROPERTY_NAME, ApiModule.class);
 
@@ -100,6 +86,26 @@ public class ApiModule extends AbstractModule {
 //        } catch (NoSuchMethodException e) {
 //            e.printStackTrace();
 //        }
+
+    }
+    
+    protected void installModules() {
+        LOGGER.debug("installing module: {}", ApiModule.class.getSimpleName());
+
+        //these modules are either free of other dependencies or they are required by later modules
+        install(new com.intuit.autumn.api.ApiModule());
+        install(new UserDirectoryModule());
+        install(new DatabaseExperimentRepositoryModule());
+        install(new DatabaseModule());
+        install(new JacksonModule());
+        install(new AuditLogModule());
+        install(new AuthorizationModule());
+
+        install(new EmailModule());
+        install(new EventsModule());
+        install(new ExperimentsModule());
+        install(new FeedbackModule());
+        install(new AnalyticsModule());
 
         LOGGER.debug("installed module: {}", ApiModule.class.getSimpleName());
     }

--- a/modules/api/src/main/java/com/intuit/wasabi/api/ApiModule.java
+++ b/modules/api/src/main/java/com/intuit/wasabi/api/ApiModule.java
@@ -89,24 +89,36 @@ public class ApiModule extends AbstractModule {
 
     }
     
-    protected void installModules() {
-        LOGGER.debug("installing module: {}", ApiModule.class.getSimpleName());
+    protected void installUserModule() {
+        install(new UserDirectoryModule());
+    }
+    
+    protected void installAuthModule() {
+        install(new AuthorizationModule());
+    }
+
+    protected void installEventModule() {
+        install(new EventsModule());
+    }
+    
+    private void installModules() {
+        LOGGER.debug("installing module: {}", ApiModule.class.getCanonicalName());
 
         //these modules are either free of other dependencies or they are required by later modules
         install(new com.intuit.autumn.api.ApiModule());
-        install(new UserDirectoryModule());
+        installUserModule();
         install(new DatabaseExperimentRepositoryModule());
         install(new DatabaseModule());
         install(new JacksonModule());
         install(new AuditLogModule());
-        install(new AuthorizationModule());
+        installAuthModule();
 
         install(new EmailModule());
-        install(new EventsModule());
+        installEventModule();
         install(new ExperimentsModule());
         install(new FeedbackModule());
         install(new AnalyticsModule());
 
-        LOGGER.debug("installed module: {}", ApiModule.class.getSimpleName());
+        LOGGER.debug("installed module: {}", ApiModule.class.getCanonicalName());
     }
 }


### PR DESCRIPTION
@felixgao @mans4singh this is part of the dedupe changes that will is needed for wasabi-intuit. [cc] @iizrailevsky 
@AndreaSuckro this change will fix the extra bindings introduced in ApiModule for the pagination changes in develop. 