### PR TITLE
dedupe assignment module

### DIFF
--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/AssignmentDecorator.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/AssignmentDecorator.java
@@ -15,23 +15,38 @@
  *******************************************************************************/
 package com.intuit.wasabi.assignment;
 
+import java.io.IOException;
+
+import com.intuit.wasabi.assignmentobjects.SegmentationProfile;
+import com.intuit.wasabi.assignmentobjects.User;
+import com.intuit.wasabi.exceptions.BucketDistributionNotFetchableException;
+import com.intuit.wasabi.experimentobjects.BucketList;
 import com.intuit.wasabi.experimentobjects.Experiment;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-
 /**
- * Decorator for creating uri from experiment
+ * Interface that provides method(s) to modify/enhance the default behavior of retrieving bucket list when
+ * retrieving assignment(s).
  */
 public interface AssignmentDecorator {
 
-
     /**
-     * Given an experiment, derive the materialized URI for calling other resources on this experiment
+     * Gets the bucket list through an external source (AssignmentDecorator). AssignmentDecorator can
+     * be a personalization engine that will execute a model to return a recommended bucket list. If the call
+     * is a successful, it merges the personalization parameters with segmentation profile
      *
-     * @param experiment {@link com.intuit.wasabi.experimentobjects.Experiment} current experiment
-     * @return URI contains the materialized URI for experiment
-     * @throws UnsupportedEncodingException
-     */
-    URI materializeUri(Experiment experiment) throws UnsupportedEncodingException;
+     * @param experiment
+     *            Experiment , it provides the modelName and modelVersion that needs to be used
+     * @param userID
+     *            UserId
+     * @param segmentationProfile
+     *            (provides the segmentationProfile to personalize the assignment)
+     * @return BucketList, which contains the buckets and the respective
+     *         allocation percentages for a userID
+     * @throws IOException
+     *             IO exception
+     * @throws com.intuit.wasabi.exceptions.BucketDistributionNotFetchableException
+     *             not able to fetch bucket distribution
+     */    
+    BucketList getBucketList(Experiment experiment, User.ID userID, SegmentationProfile segmentationProfile)
+            throws BucketDistributionNotFetchableException, IOException;
 }

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/AssignmentDecorator.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/AssignmentDecorator.java
@@ -48,5 +48,5 @@ public interface AssignmentDecorator {
      *             not able to fetch bucket distribution
      */    
     BucketList getBucketList(Experiment experiment, User.ID userID, SegmentationProfile segmentationProfile)
-            throws BucketDistributionNotFetchableException, IOException;
+            throws BucketDistributionNotFetchableException;
 }

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
@@ -170,7 +170,7 @@ public class AssignmentsImpl implements Assignments {
                            final MutexRepository mutexRepository,
                            final RuleCache ruleCache, final Pages pages,
                            final Priorities priorities,
-                           final @Nullable AssignmentDecorator assignmentDecorator,
+                           final AssignmentDecorator assignmentDecorator,
                            final @Named("ruleCache.threadPool") ThreadPoolExecutor ruleCacheExecutor,
                            final EventLog eventLog)
             throws IOException, ConnectionException {
@@ -955,13 +955,12 @@ public class AssignmentsImpl implements Assignments {
         
         BucketList bucketList = null;
         Boolean isPersonalizationEnabled = experiment.getIsPersonalizationEnabled();
-        if (isPersonalizationEnabled && !Objects.isNull(assignmentDecorator)) {
+        if (isPersonalizationEnabled) {
             try {
                 bucketList = assignmentDecorator.getBucketList(experiment, userID, segmentationProfile);
-            } catch (BucketDistributionNotFetchableException | IOException e) {
-                LOGGER.error(new StringBuilder("Error obtaining the Bucket List from ").append(assignmentDecorator.getClass().getSimpleName())
-                        .append(" for user_id )").append(userID).append(", for experiment: ").append(experiment.getLabel().toString())
-                        .append(" due to ").append(e).toString());
+            } catch (BucketDistributionNotFetchableException e) {
+                LOGGER.error("Error obtaining the Bucket List from {} for user_id {}, for experiment: {} due to {}",
+                        assignmentDecorator.getClass().getSimpleName(), userID, experiment.getLabel().toString(), e);
             } finally {
                 //TODO: add some metrics on how often this fails
                 // Logic behind the below step is to ensure the following:

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
@@ -15,14 +15,38 @@
  *******************************************************************************/
 package com.intuit.wasabi.assignment.impl;
 
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.StreamingOutput;
+
+import org.slf4j.Logger;
+
 import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Table;
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 import com.google.inject.name.Named;
-import com.intuit.autumn.client.HttpCall;
-import com.intuit.autumn.client.impl.HttpCallImplWithConnectionPooling;
 import com.intuit.hyrule.Rule;
 import com.intuit.hyrule.RuleBuilder;
 import com.intuit.hyrule.exceptions.InvalidInputException;
@@ -32,44 +56,37 @@ import com.intuit.wasabi.analyticsobjects.Parameters;
 import com.intuit.wasabi.assignment.AssignmentDecorator;
 import com.intuit.wasabi.assignment.AssignmentIngestionExecutor;
 import com.intuit.wasabi.assignment.Assignments;
-import com.intuit.wasabi.assignmentobjects.*;
+import com.intuit.wasabi.assignmentobjects.Assignment;
+import com.intuit.wasabi.assignmentobjects.AssignmentEnvelopePayload;
+import com.intuit.wasabi.assignmentobjects.RuleCache;
+import com.intuit.wasabi.assignmentobjects.SegmentationProfile;
+import com.intuit.wasabi.assignmentobjects.User;
 import com.intuit.wasabi.eventlog.EventLog;
 import com.intuit.wasabi.exceptions.AssignmentExistsException;
+import com.intuit.wasabi.exceptions.BucketDistributionNotFetchableException;
 import com.intuit.wasabi.exceptions.BucketNotFoundException;
 import com.intuit.wasabi.exceptions.ExperimentNotFoundException;
 import com.intuit.wasabi.experiment.Pages;
 import com.intuit.wasabi.experiment.Priorities;
-import com.intuit.wasabi.experimentobjects.*;
+import com.intuit.wasabi.experimentobjects.Application;
+import com.intuit.wasabi.experimentobjects.Bucket;
+import com.intuit.wasabi.experimentobjects.BucketList;
+import com.intuit.wasabi.experimentobjects.Context;
+import com.intuit.wasabi.experimentobjects.Experiment;
+import com.intuit.wasabi.experimentobjects.ExperimentBatch;
+import com.intuit.wasabi.experimentobjects.ExperimentList;
+import com.intuit.wasabi.experimentobjects.Page;
+import com.intuit.wasabi.experimentobjects.PageExperiment;
+import com.intuit.wasabi.experimentobjects.PrioritizedExperiment;
+import com.intuit.wasabi.experimentobjects.PrioritizedExperimentList;
 import com.intuit.wasabi.experimentobjects.exceptions.InvalidExperimentStateException;
 import com.intuit.wasabi.experimentobjects.exceptions.WasabiException;
-import com.intuit.wasabi.export.DatabaseExport;
-import com.intuit.wasabi.export.Envelope;
-import com.intuit.wasabi.export.WebExport;
 import com.intuit.wasabi.repository.AssignmentsRepository;
 import com.intuit.wasabi.repository.CassandraRepository;
 import com.intuit.wasabi.repository.ExperimentRepository;
 import com.intuit.wasabi.repository.MutexRepository;
 import com.intuit.wasabi.repository.cassandra.impl.ExperimentRuleCacheUpdateEnvelope;
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
-import org.slf4j.Logger;
-
-import javax.annotation.Nullable;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.StreamingOutput;
-import java.io.IOException;
-import java.security.SecureRandom;
-import java.time.Duration;
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static java.util.Objects.isNull;
-import static java.util.Objects.nonNull;
-import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Assignments implementation
@@ -104,16 +121,11 @@ public class AssignmentsImpl implements Assignments {
     protected Map<String, AssignmentIngestionExecutor> executors;
     protected AssignmentDecorator assignmentDecorator = null;
     protected ThreadPoolExecutor ruleCacheExecutor;
-    //TODO: instead of provider type, these needs to be factories
-    protected Provider<Envelope<AssignmentEnvelopePayload, DatabaseExport>> assignmentDBEnvelopeProvider;
-    //TODO: instead of provider type, these needs to be factories
-    protected Provider<Envelope<AssignmentEnvelopePayload, WebExport>> assignmentWebEnvelopeProvider;
     // Rule-Cache queue set up
     protected RuleCache ruleCache;
     /**
      * Proxy related info
      */
-    private HttpCall<PersonalizationEngineResponse> httpCall = new HttpCallImplWithConnectionPooling<>();
     private Priorities priorities;
     private Pages pages;
 
@@ -158,8 +170,6 @@ public class AssignmentsImpl implements Assignments {
                            final MutexRepository mutexRepository,
                            final RuleCache ruleCache, final Pages pages,
                            final Priorities priorities,
-                           final Provider<Envelope<AssignmentEnvelopePayload, DatabaseExport>> assignmentDBEnvelopeProvider,
-                           final Provider<Envelope<AssignmentEnvelopePayload, WebExport>> assignmentWebEnvelopeProvider,
                            final @Nullable AssignmentDecorator assignmentDecorator,
                            final @Named("ruleCache.threadPool") ThreadPoolExecutor ruleCacheExecutor,
                            final EventLog eventLog)
@@ -173,14 +183,13 @@ public class AssignmentsImpl implements Assignments {
         this.ruleCache = ruleCache;
         this.pages = pages;
         this.priorities = priorities;
-        this.assignmentDBEnvelopeProvider = assignmentDBEnvelopeProvider;
-        this.assignmentWebEnvelopeProvider = assignmentWebEnvelopeProvider;
         this.assignmentDecorator = assignmentDecorator;
         this.eventLog = eventLog;
         this.ruleCacheExecutor = ruleCacheExecutor;
         this.assignmentsRepository = assignmentsRepository;
         this.mutexRepository = mutexRepository;
         this.eventLog = eventLog;
+  
     }
 
     /**
@@ -253,7 +262,7 @@ public class AssignmentsImpl implements Assignments {
                     }
                     // Generate the assignment; this always generates an assignment,
                     // which may or may not specify a bucket
-                    assignment = generateAssignment(experiment, userID, context, selectBucket, currentDate);
+                    assignment = generateAssignment(experiment, userID, context, selectBucket, null /* no bucket list*/, currentDate, segmentationProfile);
                     assert assignment.getStatus() == Assignment.Status.NEW_ASSIGNMENT :
                             "Assignment status should have been NEW_ASSIGNMENT for " +
                                     "userID = \"" + userID + "\", experiment = \"" + experiment + "\"";
@@ -398,7 +407,7 @@ public class AssignmentsImpl implements Assignments {
                     // Generate the assignment; this always generates an assignment,
                     // which may or may not specify a bucket
                     //todo: change so this doesn't follow the 'read then write' Cassandra anti-pattern
-                    assignment = generateAssignment(experiment, userID, context, selectBucket, bucketList, currentDate);
+                    assignment = generateAssignment(experiment, userID, context, selectBucket, bucketList, currentDate, segmentationProfile);
                     assert assignment.getStatus() == Assignment.Status.NEW_ASSIGNMENT :
                             new StringBuilder("Assignment status should have been NEW_ASSIGNMENT for ")
                                     .append("userID = \"").append(userID).append("\", experiment = \"")
@@ -883,49 +892,8 @@ public class AssignmentsImpl implements Assignments {
         }
     }
 
-    Assignment generateAssignment(Experiment experiment, User.ID userID, Context context,
-                                          boolean selectBucket, Date date) {
-
-        Assignment.Builder builder = Assignment.newInstance(experiment.getID())
-                .withApplicationName(experiment.getApplicationName())
-                .withUserID(userID)
-                .withContext(context);
-
-        if (selectBucket) {
-            /*
-            With the bucket state in effect, this part of the code could also result in
-            the generation of a null assignment in cases where the selected bucket is CLOSED or EMPTY
-            In CLOSED state, the current bucket assignments to the bucket are left as is and all the
-            assignments to this bucket are made null going forward.
-
-            In EMPTY state, the current bucket assignments are made null as well as all the future assignments
-            to this bucket are made null.
-
-            Retrieves buckets from Repository if personalization is not enabled and if skipBucketRetrieval is false
-            Retrieves buckets from DE if personalization is enabled
-            * */
-            BucketList buckets = getBucketList(experiment, false);
-            Bucket assignedBucket = selectBucket(buckets.getBuckets());
-
-            //check that at least one bucket was open
-            if (assignedBucket != null) {
-                //create the bucket with bucketlabel
-                builder.withBucketLabel(assignedBucket.getLabel());
-            } else {
-                return nullAssignment(userID, experiment.getApplicationName(), experiment.getID(),
-                        Assignment.Status.NO_OPEN_BUCKETS);
-            }
-
-        } else {
-            builder.withBucketLabel(null);
-        }
-
-        Assignment result = builder.build();
-        return assignmentsRepository.assignUser(result, experiment, date);
-    }
-
-    private Assignment generateAssignment(Experiment experiment, User.ID userID, Context context, boolean selectBucket,
-                                          BucketList buckets, Date date) {
+    Assignment generateAssignment(Experiment experiment, User.ID userID, Context context, boolean selectBucket,
+                                          BucketList bucketList, Date date, SegmentationProfile segmentationProfile) {
 
         Assignment.Builder builder = Assignment.newInstance(experiment.getID())
                 .withApplicationName(experiment.getApplicationName())
@@ -944,11 +912,19 @@ public class AssignmentsImpl implements Assignments {
             to this bucket are made null.
 
             Retrieves buckets from Repository if personalization is not enabled and if skipBucketRetrieval is false
-            Retrieves buckets from DE if personalization is enabled
+            Retrieves buckets from Assignment Decorator if personalization is enabled
             */
-            assignedBucket = selectBucket(buckets.getBuckets());
+            BucketList bucketsExternal = getBucketList(experiment, userID, segmentationProfile,
+                    !Objects.isNull(bucketList) /* do not skip retrieving bucket from repository if bucketList is null */);
+            if (Objects.isNull(bucketsExternal) || bucketsExternal.getBuckets().isEmpty()) {
+                // if bucketlist obtained from Assignment Decorator is null; use the bucketlist passed into the method
+                assignedBucket = selectBucket(bucketList.getBuckets());
+            } else {
+                //else use the bucketExternal obtained from the Assignment Decorator
+                assignedBucket = selectBucket(bucketsExternal.getBuckets());
+            }
             //check that at least one bucket was open
-            if (assignedBucket != null) {
+            if (!Objects.isNull(assignedBucket)) {
                 //create the bucket with bucketlabel
                 builder.withBucketLabel(assignedBucket.getLabel());
             } else {
@@ -963,24 +939,46 @@ public class AssignmentsImpl implements Assignments {
         Assignment result = builder.build();
         return assignmentsRepository.assignUser(result, experiment, date);
     }
-
+    
     /**
      * Returns a bucketList depending on whether it is a personalization experiment or not.
-     * Retrieves buckets from DE if personalization is enabled
+     * Retrieves buckets from Assignment Decorator if personalization is enabled
      * Retrieves buckets from Repository if personalization is not enabled and if skipBucketRetrieval is false
      *
      * @param experiment          Experiment
+     * @param userID              UserId
+     * @param segmentationProfile The segmentation profile
      * @param skipBucketRetrieval If false, retrieves buckets from Repository
      * @return BucketList
      */
-    protected BucketList getBucketList(Experiment experiment, Boolean skipBucketRetrieval) {
-        BucketList buckets = null;
-        if (!skipBucketRetrieval) {
-            buckets = repository.getBuckets(experiment.getID());
+    protected BucketList getBucketList(Experiment experiment, User.ID userID, SegmentationProfile segmentationProfile, Boolean skipBucketRetrieval) {
+        
+        BucketList bucketList = null;
+        Boolean isPersonalizationEnabled = experiment.getIsPersonalizationEnabled();
+        if (isPersonalizationEnabled && !Objects.isNull(assignmentDecorator)) {
+            try {
+                bucketList = assignmentDecorator.getBucketList(experiment, userID, segmentationProfile);
+            } catch (BucketDistributionNotFetchableException | IOException e) {
+                LOGGER.error(new StringBuilder("Error obtaining the Bucket List from ").append(assignmentDecorator.getClass().getSimpleName())
+                        .append(" for user_id )").append(userID).append(", for experiment: ").append(experiment.getLabel().toString())
+                        .append(" due to ").append(e).toString());
+            } finally {
+                //TODO: add some metrics on how often this fails
+                // Logic behind the below step is to ensure the following:
+                // In the case of batch assignments, when response from Assignment Decorator fails, we skip doing a back end call to cassandra
+                // This is consistent with the different manner in which generateAssignment method is used for single and batch assignment calls.
+                if ((Objects.isNull(bucketList) || bucketList.getBuckets().isEmpty()) && !skipBucketRetrieval) {
+                    bucketList = repository.getBuckets(experiment.getID());
+                }
+            }
+        } else {
+            if (!skipBucketRetrieval) {
+                bucketList = repository.getBuckets(experiment.getID());
+            }
         }
-        return buckets;
+        return bucketList;
     }
-
+    
     protected Double rollDie() {
         return random.nextDouble();
     }
@@ -1062,23 +1060,6 @@ public class AssignmentsImpl implements Assignments {
 
         updatedSegmentationProfile.addAttribute("context", context.getContext());
         return updatedSegmentationProfile;
-    }
-
-    /**
-     * Merging response from personalization engine with segmentation profile.
-     *
-     * @param segmentationProfile           Segmentation Profile
-     * @param personalizationEngineResponse Personalization Engine Response
-     * @return SegmentationProfile the merged segmentation profile
-     */
-    SegmentationProfile mergePersonalizationResponseWithSegmentation(SegmentationProfile segmentationProfile, PersonalizationEngineResponse personalizationEngineResponse) {
-
-        if (personalizationEngineResponse != null) {
-            segmentationProfile.addAttribute("tid", personalizationEngineResponse.getTid());
-            segmentationProfile.addAttribute("data", personalizationEngineResponse.getData());
-            segmentationProfile.addAttribute("model", personalizationEngineResponse.getModel());
-        }
-        return segmentationProfile;
     }
 
     @Override

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/DefaultAssignmentDecorator.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/DefaultAssignmentDecorator.java
@@ -17,10 +17,10 @@ package com.intuit.wasabi.assignment.impl;
 
 import com.google.inject.Inject;
 import com.intuit.wasabi.assignment.AssignmentDecorator;
+import com.intuit.wasabi.assignmentobjects.SegmentationProfile;
+import com.intuit.wasabi.assignmentobjects.User.ID;
+import com.intuit.wasabi.experimentobjects.BucketList;
 import com.intuit.wasabi.experimentobjects.Experiment;
-
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
 
 public class DefaultAssignmentDecorator implements AssignmentDecorator {
 
@@ -29,7 +29,7 @@ public class DefaultAssignmentDecorator implements AssignmentDecorator {
     }
 
     @Override
-    public URI materializeUri(final Experiment experiment) throws UnsupportedEncodingException {
+    public BucketList getBucketList(Experiment experiment, ID userID, SegmentationProfile segmentationProfile) {
         return null;
     }
 }

--- a/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
+++ b/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
@@ -98,7 +98,7 @@ public class AssignmentsImplTest {
     public void setup() throws IOException, ConnectionException {
         this.assignmentsImpl = new AssignmentsImpl(new HashMap<String, AssignmentIngestionExecutor>(),
                 experimentRepository, assignmentsRepository, mutexRepository,
-                ruleCache, pages, priorities, assignmentDBEnvelopeProvider, assignmentWebEnvelopeProvider,
+                ruleCache, pages, priorities, 
                 assignmentDecorator, threadPoolExecutor, eventLog);
     }
 
@@ -135,8 +135,7 @@ public class AssignmentsImplTest {
     public void testGetSingleAssignmentNullAssignmentExperimentInDraftState() throws IOException, ConnectionException {
         AssignmentsImpl assignmentsImpl = spy(new AssignmentsImpl(new HashMap<String, AssignmentIngestionExecutor>(),
                 experimentRepository, assignmentsRepository,
-                mutexRepository, ruleCache, pages, priorities, assignmentDBEnvelopeProvider,
-                assignmentWebEnvelopeProvider, assignmentDecorator, threadPoolExecutor,
+                mutexRepository, ruleCache, pages, priorities, assignmentDecorator, threadPoolExecutor,
                 eventLog));
         Experiment.ID id = Experiment.ID.newInstance();
         Experiment experiment = mock(Experiment.class);
@@ -242,8 +241,7 @@ public class AssignmentsImplTest {
     public void testGetSingleAssignmentNullAssignmentExperimentNoProfileMatch() throws IOException, ConnectionException {
         AssignmentsImpl assignmentsImpl = spy(new AssignmentsImpl(new HashMap<String, AssignmentIngestionExecutor>(),
                 experimentRepository, assignmentsRepository,
-                mutexRepository, ruleCache, pages, priorities, assignmentDBEnvelopeProvider,
-                assignmentWebEnvelopeProvider, assignmentDecorator, threadPoolExecutor, eventLog));
+                mutexRepository, ruleCache, pages, priorities, assignmentDecorator, threadPoolExecutor, eventLog));
         Experiment.ID id = Experiment.ID.newInstance();
         Experiment experiment = mock(Experiment.class, RETURNS_DEEP_STUBS);
         when(experiment.getID()).thenReturn(id);
@@ -298,8 +296,7 @@ public class AssignmentsImplTest {
     public void testGetSingleAssignmentProfileMatchAssertNewAssignment() throws IOException, ConnectionException {
         AssignmentsImpl assignmentsImpl = spy(new AssignmentsImpl(new HashMap<String, AssignmentIngestionExecutor>(),
                 experimentRepository, assignmentsRepository,
-                mutexRepository, ruleCache, pages, priorities, assignmentDBEnvelopeProvider,
-                assignmentWebEnvelopeProvider, assignmentDecorator, threadPoolExecutor, eventLog));
+                mutexRepository, ruleCache, pages, priorities, assignmentDecorator, threadPoolExecutor, eventLog));
         Experiment.ID id = Experiment.ID.newInstance();
         Experiment experiment = mock(Experiment.class, RETURNS_DEEP_STUBS);
         Assignment assignment = mock(Assignment.class);
@@ -315,7 +312,7 @@ public class AssignmentsImplTest {
         doReturn(true).when(assignmentsImpl).doesProfileMatch(any(Experiment.class), any(SegmentationProfile.class),
                 any(HttpHeaders.class), any(Context.class));
         doReturn(assignment).when(assignmentsImpl).generateAssignment(any(Experiment.class), eq(user),
-                any(Context.class), any(Boolean.class), any(Date.class));
+                any(Context.class), any(Boolean.class), any(BucketList.class), any(Date.class), any(SegmentationProfile.class));
         doReturn(true).when(assignmentsImpl).checkMutex(any(Experiment.class), eq(user), any(Context.class));
         HttpHeaders headers = mock(HttpHeaders.class);
         when(assignment.getStatus()).thenReturn(Assignment.Status.EXPERIMENT_NOT_FOUND);
@@ -329,8 +326,7 @@ public class AssignmentsImplTest {
     public void testGetSingleAssignmentSuccess() throws IOException, ConnectionException {
         AssignmentsImpl assignmentsImpl = spy(new AssignmentsImpl(new HashMap<String, AssignmentIngestionExecutor>(),
                 experimentRepository, assignmentsRepository,
-                mutexRepository, ruleCache, pages, priorities, assignmentDBEnvelopeProvider,
-                assignmentWebEnvelopeProvider, assignmentDecorator, threadPoolExecutor, eventLog));
+                mutexRepository, ruleCache, pages, priorities, assignmentDecorator, threadPoolExecutor, eventLog));
         Experiment.ID id = Experiment.ID.newInstance();
         Experiment experiment = mock(Experiment.class, RETURNS_DEEP_STUBS);
         Assignment assignment = mock(Assignment.class);
@@ -389,8 +385,7 @@ public class AssignmentsImplTest {
         Assignment assignment = mock(Assignment.class);
         AssignmentsImpl assignmentsImpl = spy(new AssignmentsImpl(new HashMap<String, AssignmentIngestionExecutor>(),
                 experimentRepository, assignmentsRepository,
-                mutexRepository, ruleCache, pages, priorities, assignmentDBEnvelopeProvider,
-                assignmentWebEnvelopeProvider, assignmentDecorator, threadPoolExecutor, eventLog));
+                mutexRepository, ruleCache, pages, priorities, assignmentDecorator, threadPoolExecutor, eventLog));
 
         doReturn(assignment).when(assignmentsImpl).getAssignment(eq(userID), eq(appName), eq(label),
                 eq(context), any(boolean.class), any(boolean.class), eq(segmentationProfile),

--- a/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/DefaultAssignmentDecoratorTest.java
+++ b/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/DefaultAssignmentDecoratorTest.java
@@ -15,17 +15,20 @@
  *******************************************************************************/
 package com.intuit.wasabi.assignment.impl;
 
-import com.intuit.wasabi.experimentobjects.Experiment;
-import org.junit.Test;
-
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
+
+import java.io.UnsupportedEncodingException;
+
+import org.junit.Test;
+
+import com.intuit.wasabi.assignmentobjects.SegmentationProfile;
+import com.intuit.wasabi.assignmentobjects.User;
+import com.intuit.wasabi.experimentobjects.BucketList;
+import com.intuit.wasabi.experimentobjects.Experiment;
 
 /**
  * Created on 3/2/16.
@@ -37,11 +40,12 @@ public class DefaultAssignmentDecoratorTest {
         assertThat(defaultAssignmentDecorator, is(not(nullValue())));
     }
 
-    @Test public void materializeUriTest() throws UnsupportedEncodingException {
+    @Test public void getBucketListTest() throws UnsupportedEncodingException {
         Experiment experiment = mock(Experiment.class);
+        
         DefaultAssignmentDecorator defaultAssignmentDecorator = new DefaultAssignmentDecorator();
-        URI uri = defaultAssignmentDecorator.materializeUri(experiment);
-        assertThat(uri, is(nullValue()));
+        BucketList bucketList = defaultAssignmentDecorator.getBucketList(experiment, mock(User.ID.class), mock(SegmentationProfile.class));
+        
+        assertThat(bucketList, is(nullValue()));
     }
-
 }


### PR DESCRIPTION
1. Consolidated 2 generateAssignment() methods into one.
2. Eliminated redundant code and unused
mergePersonalizationResponseWithSegmentation() method
3. Updated getBucketList() method so it will call AssignmentDecorator to
retrieve recommended bucketList.

@mans4singh @bargenilesh 