### PR TITLE
adding licence without code formatting

### DIFF
--- a/modules/repository-datastax/integration-test/test/java/com/intuit/wasabi/repository/cassandra/impl/authorization/AuthorizationRepositorySetup.java
+++ b/modules/repository-datastax/integration-test/test/java/com/intuit/wasabi/repository/cassandra/impl/authorization/AuthorizationRepositorySetup.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2016 Intuit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.intuit.wasabi.repository.cassandra.impl.authorization;
 
 import com.datastax.driver.mapping.MappingManager;

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/CassandraDriverConfigurationProvider.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/CassandraDriverConfigurationProvider.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2016 Intuit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.intuit.wasabi.repository.cassandra;
 
 import com.google.inject.Inject;

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/CassandraRepositoryModule.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/CassandraRepositoryModule.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2016 Intuit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.intuit.wasabi.repository.cassandra;
 
 import com.datastax.driver.mapping.MappingManager;

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/UninterruptibleUtil.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/UninterruptibleUtil.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2016 Intuit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.intuit.wasabi.repository.cassandra;
 
 import com.datastax.driver.core.exceptions.DriverException;
@@ -10,9 +25,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-/**
- * Created by nbarge on 1/4/17.
- */
 public class UninterruptibleUtil {
 
     public static <T> Result<T> getUninterruptibly(ListenableFuture<Result<T>> aFuture, long timeout, TimeUnit unit) throws TimeoutException {

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepository.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepository.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2016 Intuit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.intuit.wasabi.repository.cassandra.impl;
 
 import com.codahale.metrics.annotation.Timed;

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/provider/index/AppPageIndexAccessorProvider.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/provider/index/AppPageIndexAccessorProvider.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2016 Intuit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.intuit.wasabi.repository.cassandra.provider.index;
 
 import com.datastax.driver.core.Session;

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/provider/index/ExperimentLabelIndexAccessorProvider.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/provider/index/ExperimentLabelIndexAccessorProvider.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2016 Intuit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.intuit.wasabi.repository.cassandra.provider.index;
 
 import com.datastax.driver.core.Session;

--- a/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/accessor/ExperimentAccessorITest.java
+++ b/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/accessor/ExperimentAccessorITest.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2016 Intuit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.intuit.wasabi.repository.cassandra.accessor;
 
 import com.datastax.driver.mapping.Result;

--- a/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/AssignmentCountEnvelopeTest.java
+++ b/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/AssignmentCountEnvelopeTest.java
@@ -1,5 +1,3 @@
-package com.intuit.wasabi.repository.cassandra.impl;
-
 /*******************************************************************************
  * Copyright 2016 Intuit
  *
@@ -15,6 +13,7 @@ package com.intuit.wasabi.repository.cassandra.impl;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
+package com.intuit.wasabi.repository.cassandra.impl;
 
 import com.intuit.wasabi.assignmentobjects.Assignment;
 import com.intuit.wasabi.eventlog.EventLog;

--- a/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepositoryTest.java
+++ b/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepositoryTest.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2016 Intuit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.intuit.wasabi.repository.cassandra.impl;
 
 import com.datastax.driver.core.exceptions.ReadTimeoutException;

--- a/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraExperimentRepositoryITest.java
+++ b/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraExperimentRepositoryITest.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2016 Intuit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.intuit.wasabi.repository.cassandra.impl;
 
 import com.datastax.driver.mapping.Result;
@@ -24,9 +39,7 @@ import java.util.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-/**
- * Integration tests
- */
+
 public class CassandraExperimentRepositoryITest extends IntegrationTestBase  {
 
     ExperimentAccessor experimentAccessor;

--- a/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraExperimentRepositoryTest.java
+++ b/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraExperimentRepositoryTest.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2016 Intuit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.intuit.wasabi.repository.cassandra.impl;
 
 import static org.junit.Assert.assertEquals;

--- a/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/database/DatabaseFavoritesRepositoryTest.java
+++ b/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/database/DatabaseFavoritesRepositoryTest.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2016 Intuit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.intuit.wasabi.repository.database;
 
 import com.googlecode.flyway.core.Flyway;


### PR DESCRIPTION
This time without cluttered codeformat changes (although we should really straighten this I think - some of the files are even indented with tabs etc.). But let https://github.com/intuit/wasabi/pull/159 worry about this.