### PR TITLE
Eliminate unnecessary multiple getExperiment calls

### DIFF
--- a/modules/analytics/src/main/java/com/intuit/wasabi/analytics/impl/AnalyticsImpl.java
+++ b/modules/analytics/src/main/java/com/intuit/wasabi/analytics/impl/AnalyticsImpl.java
@@ -528,12 +528,12 @@ public class AnalyticsImpl implements Analytics {
 
         // Uses counters
         Experiment experiment = cassandraRepository.getExperiment(experimentID);
+        if (Objects.isNull(experiment)) {
+            throw new ExperimentNotFoundException(experimentID);
+        }            
         if (release_date != null && release_date.before(experiment.getCreationTime())) {
             return assignmentRepository.getBucketAssignmentCount(experiment);
         } else {
-            if (Objects.isNull(experiment)) {
-                throw new ExperimentNotFoundException(experimentID);
-            }            
             return cassandraRepository.getAssignmentCounts(experimentID, context);
         }
     }

--- a/modules/analytics/src/main/java/com/intuit/wasabi/analytics/impl/AnalyticsImpl.java
+++ b/modules/analytics/src/main/java/com/intuit/wasabi/analytics/impl/AnalyticsImpl.java
@@ -531,6 +531,9 @@ public class AnalyticsImpl implements Analytics {
         if (release_date != null && release_date.before(experiment.getCreationTime())) {
             return assignmentRepository.getBucketAssignmentCount(experiment);
         } else {
+            if (Objects.isNull(experiment)) {
+                throw new ExperimentNotFoundException(experimentID);
+            }            
             return cassandraRepository.getAssignmentCounts(experimentID, context);
         }
     }

--- a/modules/analytics/src/main/java/com/intuit/wasabi/analytics/impl/ExperimentDetailsImpl.java
+++ b/modules/analytics/src/main/java/com/intuit/wasabi/analytics/impl/ExperimentDetailsImpl.java
@@ -89,7 +89,7 @@ public class ExperimentDetailsImpl implements ExperimentDetails {
      * @return the same ExperimentDetail object but with additional information
      */
     private ExperimentDetail getBucketData(ExperimentDetail exp) {
-        List<Bucket> buckList = buckets.getBuckets(exp.getId()).getBuckets();
+        List<Bucket> buckList = buckets.getBuckets(exp.getId(), false).getBuckets();
         exp.addBuckets(buckList);
 
         return exp;

--- a/modules/analytics/src/test/java/com/intuit/wasabi/analytics/impl/ExperimentDetailsTest.java
+++ b/modules/analytics/src/test/java/com/intuit/wasabi/analytics/impl/ExperimentDetailsTest.java
@@ -122,7 +122,7 @@ public class ExperimentDetailsTest {
         BucketList buckList = new BucketList();
         buckList.addBucket(b1);
 
-        when(buckets.getBuckets(expId)).thenReturn(buckList);
+        when(buckets.getBuckets(expId, false)).thenReturn(buckList);
 
         List<ExperimentDetail> expDetail = expDetails.getExperimentDetailsBase();
 

--- a/modules/api/src/main/java/com/intuit/wasabi/api/ExperimentsResource.java
+++ b/modules/api/src/main/java/com/intuit/wasabi/api/ExperimentsResource.java
@@ -461,7 +461,7 @@ public class ExperimentsResource {
                     READ);
         }
 
-        return httpHeader.headers().entity(buckets.getBuckets(experimentID)).build();
+        return httpHeader.headers().entity(buckets.getBuckets(experimentID, true)).build();
     }
 
     /**

--- a/modules/api/src/test/java/com/intuit/wasabi/api/ExperimentsResourceTest.java
+++ b/modules/api/src/test/java/com/intuit/wasabi/api/ExperimentsResourceTest.java
@@ -447,7 +447,7 @@ public class ExperimentsResourceTest {
         bucketList.addBucket(bucket);
         bucketList.addBucket(bucket1);
 
-        when(buckets.getBuckets(experiment.getID())).thenReturn(bucketList);
+        when(buckets.getBuckets(experiment.getID(), true)).thenReturn(bucketList);
         Response response = experimentsResource.getBuckets(experiment.getID(), null);
         Assert.assertEquals("case 1", bucketList, response.getEntity());
 

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
@@ -613,7 +613,7 @@ public class AssignmentsImpl implements Assignments {
 
         //check that the desired bucket is valid
         if (desiredBucketLabel != null) {
-            BucketList buckets = repository.getBuckets(experimentID);
+            BucketList buckets = repository.getBuckets(experimentID, false /* don't check experiment again */);
             Boolean bucketFound = false;
             for (Bucket bucket : buckets.getBuckets()) {
                 if (bucket.getLabel().equals(desiredBucketLabel) && !bucket.getState().equals(Bucket.State.EMPTY)) {
@@ -967,12 +967,12 @@ public class AssignmentsImpl implements Assignments {
                 // In the case of batch assignments, when response from Assignment Decorator fails, we skip doing a back end call to cassandra
                 // This is consistent with the different manner in which generateAssignment method is used for single and batch assignment calls.
                 if ((Objects.isNull(bucketList) || bucketList.getBuckets().isEmpty()) && !skipBucketRetrieval) {
-                    bucketList = repository.getBuckets(experiment.getID());
+                    bucketList = repository.getBuckets(experiment.getID(), false /* don't check experiment again */);
                 }
             }
         } else {
             if (!skipBucketRetrieval) {
-                bucketList = repository.getBuckets(experiment.getID());
+                bucketList = repository.getBuckets(experiment.getID(), false /* don't check experiment again */);
             }
         }
         return bucketList;

--- a/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
+++ b/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
@@ -1218,7 +1218,7 @@ public class AssignmentsImplTest {
 
         experiment.setState(Experiment.State.TERMINATED);
         Mockito.when(cassandraRepository.getExperiment(testApp, experiment.getLabel())).thenReturn(experiment);
-        Mockito.when(cassandraRepository.getBuckets(experiment.getID())).thenReturn(expBucketList);
+        Mockito.when(cassandraRepository.getBuckets(experiment.getID(), false)).thenReturn(expBucketList);
 
         boolean assertionErrorCaught = false;
         try {

--- a/modules/experiment/src/main/java/com/intuit/wasabi/experiment/Buckets.java
+++ b/modules/experiment/src/main/java/com/intuit/wasabi/experiment/Buckets.java
@@ -63,9 +63,10 @@ public interface Buckets {
      * the specified experiment.
      *
      * @param experimentId the unique experiment id
+     * @param checkExperiment check if experiment exists before querying for bucket list
      * @return a list of Bucket objects containing bucket metadata
      */
-    BucketList getBuckets(Experiment.ID experimentId);
+    BucketList getBuckets(Experiment.ID experimentId, boolean checkExperiment);
 
     /**
      * Updates a bucket by updating the specified metadata in the database.

--- a/modules/experiment/src/main/java/com/intuit/wasabi/experiment/impl/BucketsImpl.java
+++ b/modules/experiment/src/main/java/com/intuit/wasabi/experiment/impl/BucketsImpl.java
@@ -77,8 +77,8 @@ public class BucketsImpl implements Buckets {
      * {@inheritDoc}
      */
     @Override
-    public BucketList getBuckets(Experiment.ID experimentID) {
-        return cassandraRepository.getBuckets(experimentID);
+    public BucketList getBuckets(Experiment.ID experimentID, boolean checkExperiment) {
+        return cassandraRepository.getBuckets(experimentID, checkExperiment);
     }
 
     /**
@@ -162,7 +162,7 @@ public class BucketsImpl implements Buckets {
         cassandraRepository.updateBucketBatch(experimentID, bucketList);
         databaseRepository.updateBucketBatch(experimentID, bucketList);
 
-        return buckets.getBuckets(experimentID);
+        return buckets.getBuckets(experimentID, false /* don't check experiment again */);
     }
 
     /**
@@ -172,7 +172,7 @@ public class BucketsImpl implements Buckets {
     public BucketList adjustAllocationPercentages(Experiment experiment, Bucket newBucket) {
 
         double remainingAlloc = 1. - newBucket.getAllocationPercent();
-        BucketList bucketList = buckets.getBuckets(experiment.getID());
+        BucketList bucketList = buckets.getBuckets(experiment.getID(), false /* don't check experiment again */);
         BucketList newBuckets = new BucketList();
         for (Bucket bucket : bucketList.getBuckets()) {
             if (bucket.getLabel().equals(newBucket.getLabel())) {
@@ -279,7 +279,7 @@ public class BucketsImpl implements Buckets {
                 (desiredState == Bucket.State.CLOSED ||
                         desiredState == Bucket.State.EMPTY)) {
 
-            BucketList bucketList = getBuckets(experimentID);
+            BucketList bucketList = getBuckets(experimentID, false /* don't check experiment again */);
             //get starting allocation pct of bucket to be closed
             Double bucketB = roundToTwo(bucket.getAllocationPercent());
 
@@ -521,7 +521,7 @@ public class BucketsImpl implements Buckets {
         BucketList changeBucketList = new BucketList();
 
         List<List<Bucket.BucketAuditInfo>> allChanges = new ArrayList<>();
-        BucketList oldBuckets = buckets.getBuckets(experimentID);
+        BucketList oldBuckets = buckets.getBuckets(experimentID, false /* don't check experiment again */);
 
         if (oldBuckets == null) {
             throw new IllegalStateException("No Buckets could be found for this experiment");

--- a/modules/experiment/src/main/java/com/intuit/wasabi/experiment/impl/ExperimentsImpl.java
+++ b/modules/experiment/src/main/java/com/intuit/wasabi/experiment/impl/ExperimentsImpl.java
@@ -196,7 +196,7 @@ public class ExperimentsImpl implements Experiments {
             * */
             if (currentState.equals(DRAFT) && desiredState.equals(RUNNING)) {
                 // Throw an exception if the sanity-check fails
-                BucketList bucketList = buckets.getBuckets(experimentID);
+                BucketList bucketList = buckets.getBuckets(experimentID, false /* don't check experiment again */);
                 validator.validateExperimentBuckets(bucketList.getBuckets());
             }
         }

--- a/modules/experiment/src/test/java/com/intuit/wasabi/experiment/BucketsImplTest.java
+++ b/modules/experiment/src/test/java/com/intuit/wasabi/experiment/BucketsImplTest.java
@@ -142,7 +142,7 @@ public class BucketsImplTest {
                 .withState(Experiment.State.DRAFT)
                 .build();
 
-        when(buckets.getBuckets(experimentID)).thenReturn(bucketList);
+        when(buckets.getBuckets(experimentID, false)).thenReturn(bucketList);
 
         BucketList newBuckets = bucketsImpl.adjustAllocationPercentages(experiment, newBucket);
         bucket.setAllocationPercent(.42);

--- a/modules/experiment/src/test/java/com/intuit/wasabi/experiment/impl/ExperimentsImplTest.java
+++ b/modules/experiment/src/test/java/com/intuit/wasabi/experiment/impl/ExperimentsImplTest.java
@@ -262,10 +262,10 @@ public class ExperimentsImplTest {
         expImpl.checkStateTransition(experimentID, currentState,null);
 
         BucketList bucketList = mock(BucketList.class);
-        when(buckets.getBuckets(eq(experimentID))).thenReturn(bucketList);
+        when(buckets.getBuckets(experimentID, false)).thenReturn(bucketList);
         expImpl.checkStateTransition(experimentID, Experiment.State.DRAFT, Experiment.State.RUNNING);
         verify(validator, times(1)).validateStateTransition(Experiment.State.DRAFT, Experiment.State.RUNNING);
-        verify(buckets, times(1)).getBuckets(experimentID);
+        verify(buckets, times(1)).getBuckets(experimentID, false);
         verify(validator, times(1)).validateExperimentBuckets(bucketList.getBuckets());
 
     }

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/ExperimentRepository.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/ExperimentRepository.java
@@ -124,11 +124,11 @@ public interface ExperimentRepository {
      * Return a list of bucket IDs for the specified experiment
      *
      * @param experimentID id of the experiment
+     * @param checkExperiment check if experiment exists before querying for bucket list
      * @return a list of buckets of that experiment
      *
      */
-    BucketList getBuckets(Experiment.ID experimentID);
-
+    BucketList getBuckets(Experiment.ID experimentID, boolean checkExperiment);
 
     /**
      * Create a new bucket for the specified experiment

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/CassandraExperimentRepository.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/CassandraExperimentRepository.java
@@ -411,7 +411,7 @@ public class CassandraExperimentRepository implements ExperimentRepository {
 		LOGGER.debug("Get Assignment Counts for Experiment {} and context {}",
 				new Object[] { experimentID, context });
 
-		List<Bucket> bucketList = getBuckets(experimentID).getBuckets();
+		List<Bucket> bucketList = getBuckets(experimentID, false /* caller already checks if experiment exists */).getBuckets();
 
 		AssignmentCounts.Builder builder = new AssignmentCounts.Builder();
 		builder.withExperimentID(experimentID);
@@ -977,7 +977,7 @@ public class CassandraExperimentRepository implements ExperimentRepository {
         }
 
         BucketList buckets;
-        buckets = getBuckets(experimentID);
+        buckets = getBuckets(experimentID, false);
         return buckets;
 	}
 
@@ -1045,7 +1045,7 @@ public class CassandraExperimentRepository implements ExperimentRepository {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public BucketList getBuckets(Experiment.ID experimentID) {
+	public BucketList getBuckets(Experiment.ID experimentID, boolean checkExperiment) {
 
 		LOGGER.debug("Getting buckets for {}", experimentID);
 		
@@ -1053,11 +1053,13 @@ public class CassandraExperimentRepository implements ExperimentRepository {
 				"Parameter \"experimentID\" cannot be null");
 
 		try {
-			// Check if the experiment is live
-			Experiment experiment = getExperiment(experimentID);
-			if (experiment == null) {
-				throw new ExperimentNotFoundException(experimentID);
-			}
+            if (checkExperiment) {
+                // Check if the experiment is live
+                Experiment experiment = getExperiment(experimentID);
+                if (experiment == null) {
+                    throw new ExperimentNotFoundException(experimentID);
+                }
+            }
 	
 			 Result<com.intuit.wasabi.repository.cassandra.pojo.Bucket> bucketPojos = 
 					 bucketAccessor.getBucketByExperimentId(experimentID.getRawID());

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/database/DatabaseExperimentRepository.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/database/DatabaseExperimentRepository.java
@@ -686,7 +686,7 @@ public class DatabaseExperimentRepository implements ExperimentRepository {
 //    }
 
     @Override
-    public BucketList getBuckets(Experiment.ID experimentID)
+    public BucketList getBuckets(Experiment.ID experimentID, boolean checkExperiment)
             throws RepositoryException {
 
         final String SQL_SELECT_ID =

--- a/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraExperimentRepositoryITest.java
+++ b/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraExperimentRepositoryITest.java
@@ -713,7 +713,7 @@ public class CassandraExperimentRepositoryITest extends IntegrationTestBase  {
 
 	@Test(expected=ExperimentNotFoundException.class)
 	public void testGetBucketsThrowsExperimentNotFoundException() {
-		BucketList buckets = repository.getBuckets(Experiment.ID.newInstance());
+		BucketList buckets = repository.getBuckets(Experiment.ID.newInstance(), false);
 	}
 
 	@Test
@@ -723,7 +723,7 @@ public class CassandraExperimentRepositoryITest extends IntegrationTestBase  {
 		bucketList1.addBucket(bucket2);
 		repository.updateBucketBatch(experimentID1, bucketList1);
 
-		 BucketList buckets = repository.getBuckets(experimentID1);
+		 BucketList buckets = repository.getBuckets(experimentID1, false);
 		assertEquals("Value should be equal", 2, buckets.getBuckets().size());
 		List<Bucket> bucketsResponse = buckets.getBuckets();
 		
@@ -756,12 +756,12 @@ public class CassandraExperimentRepositoryITest extends IntegrationTestBase  {
 		bucketList1.addBucket(bucket2);
 		repository.updateBucketBatch(experimentID1, bucketList1);
 
-		BucketList buckets = repository.getBuckets(experimentID1);
+		BucketList buckets = repository.getBuckets(experimentID1, false);
 		assertEquals("Value should be equal", 2, buckets.getBuckets().size());
 
 		repository.deleteBucket(experimentID1, bucket1.getLabel());
 		
-		buckets = repository.getBuckets(experimentID1);
+		buckets = repository.getBuckets(experimentID1, false);
 		
 		assertEquals("Value should be equal", 1, buckets.getBuckets().size());
 		List<Bucket> bucketsResponse = buckets.getBuckets();
@@ -778,12 +778,12 @@ public class CassandraExperimentRepositoryITest extends IntegrationTestBase  {
 		bucketList1.addBucket(bucket1);
 		repository.updateBucketBatch(experimentID1, bucketList1);
 
-		BucketList buckets = repository.getBuckets(experimentID1);
+		BucketList buckets = repository.getBuckets(experimentID1, false);
 		assertEquals("Value should be equal", 1, buckets.getBuckets().size());
 
 		repository.deleteBucket(experimentID1, bucket1.getLabel());
 		
-		buckets = repository.getBuckets(experimentID1);
+		buckets = repository.getBuckets(experimentID1, false);
 		
 		assertEquals("Value should be equal", 0, buckets.getBuckets().size());
 		

--- a/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraExperimentRepositoryTest.java
+++ b/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraExperimentRepositoryTest.java
@@ -448,7 +448,7 @@ public class CassandraExperimentRepositoryTest {
 	@Test(expected=RepositoryException.class)
 	public void testGetBucketsAccessorMockThrowsException() {
 		repository.setBucketAccessor(mockBucketAccessor);
-		BucketList buckets = repository.getBuckets(experimentID1);
+		BucketList buckets = repository.getBuckets(experimentID1, false);
 	}
 
 	@Test(expected=RepositoryException.class)

--- a/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/database/DatabaseExperimentRepositoryTest.java
+++ b/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/database/DatabaseExperimentRepositoryTest.java
@@ -479,7 +479,7 @@ public class DatabaseExperimentRepositoryTest {
         List firstQueryResult = mock(List.class);
         when(transaction.select(anyString(), eq(id), eq(DELETED.toString()))).thenReturn(firstQueryResult);
         when(firstQueryResult.size()).thenReturn(0);
-        BDDCatchException.when(repository).getBuckets(id);
+        BDDCatchException.when(repository).getBuckets(id, false);
         BDDCatchException.then(caughtException())
                 .isInstanceOf(ExperimentNotFoundException.class)
                 .hasMessageContaining("Experiment")
@@ -496,7 +496,7 @@ public class DatabaseExperimentRepositoryTest {
         when(queryMap.get("is_control")).thenReturn(true);
         when(queryMap.get("payload")).thenReturn("payload");
         when(transaction.select(anyString(), eq(id))).thenReturn(secondQueryResult);
-        BucketList result = repository.getBuckets(id);
+        BucketList result = repository.getBuckets(id, false);
         assertThat(result, is(not(nullValue())));
         assertThat(result.getBuckets().size(), is(1));
         assertThat(result.getBuckets().get(0).getExperimentID(), is(id));


### PR DESCRIPTION
This change is to eliminate the unnecessary multiple calls to get experiment from repository (Cassandra) and therefore it will improve overall performance of single assignment call, batch assignment call and other call that requires retrieving of bucket list. For example, the following methods retrieve experiment from repository more than 1 time in the current code base.

AssignmentImpl->getSingleAssignment
AssignmentImpl->doBatchAssignments
ExperimentResource->putBucket()
BucketsImpl->createBucket()
..
..

This is not an attempt to use Datastax async call for single assignment to improve performance. I manually traced all call stacks to getBuckets(Experiment.ID experimentId). Only 1 caller requires to check/retrieve experiment again. This method is now changed to getBuckets(Experiment.ID experimentId, boolean checkExperiment).
