### PR TITLE
fixing the cardview for production

### DIFF
--- a/modules/analytics-objects/src/main/java/com/intuit/wasabi/analyticsobjects/wrapper/ExperimentDetail.java
+++ b/modules/analytics-objects/src/main/java/com/intuit/wasabi/analyticsobjects/wrapper/ExperimentDetail.java
@@ -253,9 +253,10 @@ public class ExperimentDetail {
     }
 
     private void setState(Experiment.State state) {
-        if (state != null)
+        if (state != null || Experiment.State.DELETED.equals(state))
             this.state = state;
-        else throw new IllegalArgumentException("Experiment.State is not allowed to be null for ExperimentDetail");
+        else
+            throw new IllegalArgumentException("Experiment.State is not allowed to be null or DELETED for ExperimentDetail");
     }
 
     public Experiment.Label getLabel() {

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/CassandraExperimentRepository.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/CassandraExperimentRepository.java
@@ -696,13 +696,13 @@ public class CassandraExperimentRepository implements ExperimentRepository {
             			experimentAccessor.getExperiments(uuids);
             	
                 List<Experiment> experiments = experimentPojos.all().stream().filter(experiment -> 
-                	! experiment.getState().equals(Experiment.State.DELETED))
+                	!experiment.getState().equals(Experiment.State.DELETED.name()))
                 	.map(ExperimentHelper::makeExperiment).collect(Collectors.toList());
                 
                 result.setExperiments(experiments);
             }
         } catch (Exception e) {
-    		LOGGER.error("Errro while getting experiments {}", experimentIDs, e);
+    		LOGGER.error("Error while getting experiments {}", experimentIDs, e);
             throw new RepositoryException("Could not retrieve the experiments for the collection of experimentIDs", e);
         }
         


### PR DESCRIPTION
The basic problem was also an error in the way the experiments where retrieved, since the experimentpojo stored the state only as a string and not as an enum the check for the deleted state could never succeed.