### PR TITLE
Feature/assignments performance optimizations r2

### DIFF
--- a/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
+++ b/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
@@ -39,7 +39,6 @@ import com.intuit.wasabi.repository.ExperimentRepository;
 import com.intuit.wasabi.repository.MutexRepository;
 import com.intuit.wasabi.repository.cassandra.impl.ExperimentRuleCacheUpdateEnvelope;
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,7 +49,6 @@ import javax.ws.rs.core.HttpHeaders;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.hamcrest.core.Is.is;
@@ -62,6 +60,7 @@ import static org.mockito.BDDMockito.eq;
 import static org.mockito.BDDMockito.spy;
 import static org.mockito.BDDMockito.times;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -910,6 +909,69 @@ public class AssignmentsImplTest {
         assertTrue(assignment.getStatus() == Assignment.Status.NEW_ASSIGNMENT);
 
     }
+
+    @Test
+    public void createAssignmentObjectTest() throws IOException, ConnectionException {
+
+        //------- Prepare input data
+        Date date = new Date();
+        SegmentationProfile segmentationProfile = null;
+        User.ID userID = User.ID.valueOf("test-user-1");
+        Context context = Context.valueOf("TEST");
+        boolean selectBucket = true;
+        Experiment exp1 = Experiment.withID(Experiment.ID.valueOf(UUID.randomUUID()))
+                .withApplicationName(Application.Name.valueOf("test-app-1"))
+                .withLabel(Experiment.Label.valueOf("test-exp-1"))
+                .withState(Experiment.State.RUNNING)
+                .withIsPersonalizationEnabled(false)
+                .build();
+        BucketList bucketList1 = new BucketList();
+        bucketList1.addBucket(Bucket.newInstance(exp1.getID(), Bucket.Label.valueOf("bucket-1")).withAllocationPercent(0.9d).withPayload("bucket1").withState(Bucket.State.OPEN).build());
+        bucketList1.addBucket(Bucket.newInstance(exp1.getID(), Bucket.Label.valueOf("bucket-2")).withAllocationPercent(0.1d).withPayload("bucket-2").withState(Bucket.State.OPEN).build());
+
+        //--------- Mock calls
+        when(assignmentDecorator.getBucketList(exp1, userID, segmentationProfile)).thenReturn(bucketList1);
+
+        //--------- Make actual call
+        Assignment newAssignment = assignmentsImpl.createAssignmentObject(exp1, userID, context, selectBucket, bucketList1, date, segmentationProfile);
+
+        //---------- Validate result
+        assertTrue(newAssignment!=null);
+        assertTrue(newAssignment.getStatus().equals(Assignment.Status.NEW_ASSIGNMENT));
+
+    }
+
+    @Test
+    public void createAssignmentObjectTestForNoOpenBucket() throws IOException, ConnectionException {
+
+        //------- Prepare input data
+        Date date = new Date();
+        SegmentationProfile segmentationProfile = null;
+        User.ID userID = User.ID.valueOf("test-user-1");
+        Context context = Context.valueOf("TEST");
+        boolean selectBucket = true;
+        Experiment exp1 = Experiment.withID(Experiment.ID.valueOf(UUID.randomUUID()))
+                .withApplicationName(Application.Name.valueOf("test-app-1"))
+                .withLabel(Experiment.Label.valueOf("test-exp-1"))
+                .withState(Experiment.State.RUNNING)
+                .withIsPersonalizationEnabled(false)
+                .build();
+        BucketList bucketList1 = new BucketList();
+        bucketList1.addBucket(Bucket.newInstance(exp1.getID(), Bucket.Label.valueOf("bucket-1")).withAllocationPercent(0.0d).withPayload("bucket1").withState(Bucket.State.CLOSED).build());
+        bucketList1.addBucket(Bucket.newInstance(exp1.getID(), Bucket.Label.valueOf("bucket-2")).withAllocationPercent(0.0d).withPayload("bucket-2").withState(Bucket.State.CLOSED).build());
+
+        //--------- Mock calls
+        when(assignmentDecorator.getBucketList(exp1, userID, segmentationProfile)).thenReturn(bucketList1);
+
+        //--------- Make actual call
+        Assignment newAssignment = assignmentsImpl.createAssignmentObject(exp1, userID, context, selectBucket, bucketList1, date, segmentationProfile);
+
+        //---------- Validate result
+        assertTrue(newAssignment!=null);
+        assertTrue(newAssignment.getStatus().equals(Assignment.Status.NO_OPEN_BUCKETS));
+
+    }
+
 
     @Test
     public void doBatchAssignmentsTest() throws IOException, ConnectionException {

--- a/modules/database/src/main/java/com/intuit/wasabi/database/DBITransactionFactory.java
+++ b/modules/database/src/main/java/com/intuit/wasabi/database/DBITransactionFactory.java
@@ -86,7 +86,8 @@ public class DBITransactionFactory extends TransactionFactory {
                 LOGGER.error("Unable to do check", ex);
                 msg = ex.getMessage();
             } finally {
-                ((DBITransaction) trans).close();
+                //No need to close here as it (handle) gets closed as part of select() operation.
+                //((DBITransaction) trans).close();
             }
 
             return res ? Result.healthy() : Result.unhealthy(msg);

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/AssignmentsRepository.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/AssignmentsRepository.java
@@ -78,7 +78,7 @@ public interface AssignmentsRepository {
      * @param date       Date of user assignment
      * @return Resulting assignment
      */
-    Assignment assignUser(List<Pair<Experiment, Assignment>> assignments, Date date);
+    Assignment assignUsersInBatch(List<Pair<Experiment, Assignment>> assignments, Date date);
 
     /**
      * Get assignments

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/AssignmentsRepository.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/AssignmentsRepository.java
@@ -27,6 +27,7 @@ import com.intuit.wasabi.experimentobjects.Context;
 import com.intuit.wasabi.experimentobjects.Experiment;
 import com.intuit.wasabi.experimentobjects.ExperimentBatch;
 import com.intuit.wasabi.experimentobjects.PrioritizedExperimentList;
+import org.apache.commons.lang3.tuple.Pair;
 
 import javax.ws.rs.core.StreamingOutput;
 import java.time.OffsetDateTime;
@@ -69,6 +70,15 @@ public interface AssignmentsRepository {
      * @return Resulting assignment
      */
     Assignment assignUser(Assignment assignment, Experiment experiment, Date date);
+
+    /**
+     * Assign users to experiments in a batch
+     *
+     * @param assignments pair of experiment and assignment
+     * @param date       Date of user assignment
+     * @return Resulting assignment
+     */
+    Assignment assignUser(List<Pair<Experiment, Assignment>> assignments, Date date);
 
     /**
      * Get assignments

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/CassandraRepositoryModule.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/CassandraRepositoryModule.java
@@ -117,8 +117,8 @@ public class CassandraRepositoryModule extends AbstractModule {
         bind(BucketAssignmentCountAccessor.class).toProvider(BucketAssignmentCountAccessorProvider.class).in(Singleton.class);
         //Bind those export
         bind(UserAssignmentExportAccessor.class).toProvider(UserAssignmentExportAccessorProvider.class).in(Singleton.class);
-
-        bindAssignmentsCountThreadPoolExecutor(assignmentsCountThreadPoolSize);
+        //Bind assignments Count thread pool executor
+        bind(ThreadPoolExecutor.class).annotatedWith(named("AssignmentsCountThreadPoolExecutor")).to(AssignmentCountExecutor.class).in(Singleton.class);
 
         //Bind those repositories
         bind(AssignmentsRepository.class).to(CassandraAssignmentsRepository.class).in(Singleton.class);
@@ -130,17 +130,4 @@ public class CassandraRepositoryModule extends AbstractModule {
         bind(PrioritiesRepository.class).to(CassandraPrioritiesRepository.class).in(Singleton.class);
         bind(ExperimentRepository.class).annotatedWith(CassandraRepository.class).to(CassandraExperimentRepository.class).in(Singleton.class);
     }
-
-    private void bindAssignmentsCountThreadPoolExecutor(int assignmentsCountThreadPoolSize) {
-        LinkedBlockingQueue assignmentsCountQueue = new LinkedBlockingQueue<>();
-        ThreadPoolExecutor assignmentsCountThreadPoolExecutor = new ThreadPoolExecutor(
-                assignmentsCountThreadPoolSize,
-                assignmentsCountThreadPoolSize,
-                0L,
-                MILLISECONDS,
-                assignmentsCountQueue);
-
-        bind(ThreadPoolExecutor.class).annotatedWith(named("AssignmentsCountThreadPoolExecutor")).toInstance(assignmentsCountThreadPoolExecutor);
-    }
-
 }

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/CassandraRepositoryModule.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/CassandraRepositoryModule.java
@@ -16,6 +16,7 @@
 package com.intuit.wasabi.repository.cassandra;
 
 import com.datastax.driver.mapping.MappingManager;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.AbstractModule;
 import com.google.inject.name.Names;
 import com.intuit.wasabi.cassandra.datastax.CassandraDriver;
@@ -40,12 +41,15 @@ import org.slf4j.Logger;
 
 import javax.inject.Singleton;
 import java.util.Properties;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static com.google.inject.name.Names.named;
 import static com.intuit.autumn.utils.PropertyFactory.create;
 import static com.intuit.autumn.utils.PropertyFactory.getProperty;
 import static java.lang.Boolean.TRUE;
 import static java.lang.Integer.parseInt;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class CassandraRepositoryModule extends AbstractModule {
@@ -61,8 +65,8 @@ public class CassandraRepositoryModule extends AbstractModule {
                 .toInstance(getProperty("assign.user.to.export", properties));
         bind(String.class).annotatedWith(named("assign.bucket.count"))
                 .toInstance(getProperty("assign.bucket.count", properties));
-        bind(Integer.class).annotatedWith(named("export.pool.size"))
-                .toInstance(parseInt(getProperty("export.pool.size", properties, "5")));
+        Integer assignmentsCountThreadPoolSize = parseInt(getProperty("export.pool.size", properties, "5"));
+        bind(Integer.class).annotatedWith(named("export.pool.size")).toInstance(assignmentsCountThreadPoolSize);
         bind(Boolean.class).annotatedWith(named("assign.user.to.old"))
                 .toInstance(Boolean.valueOf(getProperty("assign.user.to.old", properties, TRUE.toString())));
         bind(Boolean.class).annotatedWith(named("assign.user.to.new"))
@@ -114,6 +118,8 @@ public class CassandraRepositoryModule extends AbstractModule {
         //Bind those export
         bind(UserAssignmentExportAccessor.class).toProvider(UserAssignmentExportAccessorProvider.class).in(Singleton.class);
 
+        bindAssignmentsCountThreadPoolExecutor(assignmentsCountThreadPoolSize);
+
         //Bind those repositories
         bind(AssignmentsRepository.class).to(CassandraAssignmentsRepository.class).in(Singleton.class);
         bind(AuditLogRepository.class).to(CassandraAuditLogRepository.class).in(Singleton.class);
@@ -124,4 +130,17 @@ public class CassandraRepositoryModule extends AbstractModule {
         bind(PrioritiesRepository.class).to(CassandraPrioritiesRepository.class).in(Singleton.class);
         bind(ExperimentRepository.class).annotatedWith(CassandraRepository.class).to(CassandraExperimentRepository.class).in(Singleton.class);
     }
+
+    private void bindAssignmentsCountThreadPoolExecutor(int assignmentsCountThreadPoolSize) {
+        LinkedBlockingQueue assignmentsCountQueue = new LinkedBlockingQueue<>();
+        ThreadPoolExecutor assignmentsCountThreadPoolExecutor = new ThreadPoolExecutor(
+                assignmentsCountThreadPoolSize,
+                assignmentsCountThreadPoolSize,
+                0L,
+                MILLISECONDS,
+                assignmentsCountQueue);
+
+        bind(ThreadPoolExecutor.class).annotatedWith(named("AssignmentsCountThreadPoolExecutor")).toInstance(assignmentsCountThreadPoolExecutor);
+    }
+
 }

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/accessor/UserAssignmentAccessor.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/accessor/UserAssignmentAccessor.java
@@ -16,6 +16,7 @@
 package com.intuit.wasabi.repository.cassandra.accessor;
 
 import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.mapping.Result;
 import com.datastax.driver.mapping.annotations.Accessor;
 import com.datastax.driver.mapping.annotations.Query;
@@ -36,6 +37,14 @@ public interface UserAssignmentAccessor {
     @Query("insert into user_assignment (experiment_id, user_id, context, created)" +
             " values (?, ?, ?, ?)")
     ResultSet insertBy(UUID uuid, String userId, String context, Date created);
+
+    @Query("insert into user_assignment (experiment_id, user_id, context, created, bucket_label)" +
+            " values (?, ?, ?, ?, ?)")
+    ResultSetFuture asyncInsertBy(UUID uuid, String userId, String context, Date created, String bucketLabel);
+
+    @Query("insert into user_assignment (experiment_id, user_id, context, created)" +
+            " values (?, ?, ?, ?)")
+    ResultSetFuture asyncInsertBy(UUID uuid, String userId, String context, Date created);
 
     @Query("select * from user_assignment where experiment_id = ? and user_id = ? and context = ?")
     Result<UserAssignment> selectBy(UUID experimentId, String userId, String context);

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/accessor/index/ExperimentUserIndexAccessor.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/accessor/index/ExperimentUserIndexAccessor.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package com.intuit.wasabi.repository.cassandra.accessor.index;
 
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.mapping.Result;
 import com.datastax.driver.mapping.annotations.Accessor;
@@ -37,7 +39,16 @@ public interface ExperimentUserIndexAccessor {
             " values (?, ?, ?, ?)")
     ResultSet insertBy(String userId, String context, String appName, UUID experimentId);
 
-    
+
+    @Query("insert into experiment_user_index (user_id, context, app_name, experiment_id, bucket)" +
+            " values (?, ?, ?, ?, ?)")
+    BoundStatement insertBoundStatement(String userId, String context, String appName, UUID experimentId, String bucketLabel);
+
+    @Query("insert into experiment_user_index (user_id, context, app_name, experiment_id)" +
+            " values (?, ?, ?, ?)")
+    BoundStatement insertBoundStatement(String userId, String context, String appName, UUID experimentId);
+
+
     @Query("select * from experiment_user_index where user_id = ? and app_name = ? and context = ?")
     Result<ExperimentUserByUserIdContextAppNameExperimentId> selectBy(String userId, String appName, String context);
 

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/accessor/index/UserAssignmentIndexAccessor.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/accessor/index/UserAssignmentIndexAccessor.java
@@ -16,6 +16,7 @@
 package com.intuit.wasabi.repository.cassandra.accessor.index;
 
 import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.mapping.Result;
 import com.datastax.driver.mapping.annotations.Accessor;
 import com.datastax.driver.mapping.annotations.Query;
@@ -54,6 +55,34 @@ public interface UserAssignmentIndexAccessor {
     @Query("insert into user_assignment_by_userid (experiment_id, user_id, context, created)" +
             " values (?, ?, ?, ?)")
     ResultSet insertBy(UUID uuid, String userId, String context, Date created);
+
+	/**
+	 * Insert record into table based on attributes asynchronously
+	 *
+	 * @param uuid
+	 * @param userId
+	 * @param context
+	 * @param created
+	 * @param bucketLabel
+	 * @return resultSet
+	 */
+	@Query("insert into user_assignment_by_userid (experiment_id, user_id, context, created, bucket_label)" +
+			" values (?, ?, ?, ?, ?)")
+	ResultSetFuture asyncInsertBy(UUID uuid, String userId, String context, Date created, String bucketLabel);
+
+	/**
+	 * Insert record based on attributes asynchronously
+	 *
+	 * @param uuid
+	 * @param userId
+	 * @param context
+	 * @param created
+	 * @return resultSet
+	 */
+	@Query("insert into user_assignment_by_userid (experiment_id, user_id, context, created)" +
+			" values (?, ?, ?, ?)")
+	ResultSetFuture asyncInsertBy(UUID uuid, String userId, String context, Date created);
+
 
 	/**
 	 * Get rows by parameters

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/accessor/index/UserBucketIndexAccessor.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/accessor/index/UserBucketIndexAccessor.java
@@ -16,6 +16,7 @@
 package com.intuit.wasabi.repository.cassandra.accessor.index;
 
 import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.mapping.annotations.Accessor;
 import com.datastax.driver.mapping.annotations.Query;
 
@@ -70,5 +71,29 @@ public interface UserBucketIndexAccessor {
      */
     @Query("delete from user_bucket_index where experiment_id = ? and user_id = ? and context = ? and bucket_label = ?")
     void deleteBy(UUID experimentId, String userId, String context, String bucketLabel);
+
+
+    /**
+     * Insert entry into the table
+     * @param experimentId
+     * @param userId
+     * @param context
+     * @param assigned
+     */
+    @Query("insert into user_bucket_index (experiment_id, user_id, context, assigned) values (?, ?, ?, ?)")
+    ResultSetFuture asyncInsertBy(UUID experimentId, String userId, String context, Date assigned);
+
+
+    /**
+     * Insert entry into the table
+     * @param experimentId
+     * @param userId
+     * @param context
+     * @param assigned
+     * @param bucketLabel
+     */
+    @Query("insert into user_bucket_index (experiment_id, user_id, context, assigned, bucket_label) values (?, ?, ?, ?, ?)")
+    ResultSetFuture asyncInsertBy(UUID experimentId, String userId, String context, Date assigned, String bucketLabel);
+
 
 }

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/AssignmentCountExecutor.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/AssignmentCountExecutor.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright 2016 Intuit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.intuit.wasabi.repository.cassandra.impl;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This class is created to overcome Guice exception
+ *
+ */
+public class AssignmentCountExecutor extends ThreadPoolExecutor {
+
+    @Inject
+    public AssignmentCountExecutor(@Named("export.pool.size") Integer corePoolSize,
+                                   @Named("export.pool.size") Integer maximumPoolSize) {
+        super(corePoolSize, maximumPoolSize, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
+    }
+}

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepository.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepository.java
@@ -676,9 +676,7 @@ public class CassandraAssignmentsRepository implements AssignmentsRepository {
             rFutures.add(asyncIndexUserToBucket(pair.getRight()));
         });
 
-        rFutures.forEach(resultSetFuture -> {
-            resultSetFuture.getUninterruptibly();
-        });
+        rFutures.forEach(ResultSetFuture::getUninterruptibly);
         logger.debug("Finished asyncIndexUserToBucket");
     }
 

--- a/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepositoryTest.java
+++ b/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepositoryTest.java
@@ -40,7 +40,6 @@ import com.intuit.wasabi.experimentobjects.Bucket;
 import com.intuit.wasabi.experimentobjects.Experiment;
 import com.intuit.wasabi.repository.ExperimentRepository;
 import com.intuit.wasabi.repository.RepositoryException;
-import com.intuit.wasabi.repository.cassandra.UninterruptibleUtil;
 import com.intuit.wasabi.repository.cassandra.accessor.*;
 import com.intuit.wasabi.repository.cassandra.accessor.count.BucketAssignmentCountAccessor;
 import com.intuit.wasabi.repository.cassandra.accessor.export.UserAssignmentExportAccessor;
@@ -61,12 +60,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1658,7 +1652,7 @@ public class CassandraAssignmentsRepositoryTest {
         //------ Make final call
         boolean success = true;
         try {
-            repository.assignUser(assignmentPairs, date);
+            repository.assignUsersInBatch(assignmentPairs, date);
         } catch (Exception e) {
             logger.error("Failed to execute assignUser test...", e);
             success = false;

--- a/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepositoryTest.java
+++ b/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepositoryTest.java
@@ -120,7 +120,6 @@ public class CassandraAssignmentsRepositoryTest {
     CassandraAssignmentsRepository repository;
     CassandraAssignmentsRepository spyRepository;
     UUID experimentId = UUID.fromString("4d4d8f3b-3b81-44f3-968d-d1c1a48b4ac8");
-    UUID experimentId2 = UUID.fromString("4d4d8f3b-3b81-44f3-968d-d1c1a58b4ac8");
 
     public static final Application.Name APPLICATION_NAME = Application.Name.valueOf("testApp");
 


### PR DESCRIPTION
This pull request contains following changes:

1. Performance Improvement: In case of batch-assignment use case, create New Assignments in cassandra DB in a BATCH. 
To create assignments in a batch, I have used BatchStatement (when all INSERTs are going into SAME partition)  and asynchronous calls (when INSERTs are going into DIFFERENT partitions) wherever applicable.

2. Fixed issue of printing unnecessary warning "[DBITransaction.java:246] no handle present - this should not happen"

@jcwuzoegiver @mans4singh @iizrailevsky 
