### PR TITLE
Short term fix for memory exhaustion issue due to growing ingestion queue

### DIFF
--- a/modules/api/src/main/java/com/intuit/wasabi/api/AssignmentsResource.java
+++ b/modules/api/src/main/java/com/intuit/wasabi/api/AssignmentsResource.java
@@ -38,6 +38,7 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 
+import org.apache.commons.httpclient.HttpStatus;
 import org.slf4j.Logger;
 
 import java.util.List;
@@ -565,7 +566,7 @@ public class AssignmentsResource {
         Username userName = authorization.getUser(authorizationHeader);
         authorization.checkSuperAdmin(userName);
         assignments.flushMessages();
-        return httpHeader.headers().build();
+        return httpHeader.headers(HttpStatus.SC_NO_CONTENT).build();
     }
 
     private Map<String, Object> toMap(final Assignment assignment) {

--- a/modules/api/src/test/java/com/intuit/wasabi/api/AssignmentsResourceTest.java
+++ b/modules/api/src/test/java/com/intuit/wasabi/api/AssignmentsResourceTest.java
@@ -18,9 +18,14 @@ package com.intuit.wasabi.api;
 import com.intuit.wasabi.assignment.Assignments;
 import com.intuit.wasabi.assignmentobjects.Assignment;
 import com.intuit.wasabi.assignmentobjects.Assignment.Status;
+import com.intuit.wasabi.authenticationobjects.UserInfo;
+import com.intuit.wasabi.authenticationobjects.UserInfo.Username;
+import com.intuit.wasabi.authorization.Authorization;
+import com.intuit.wasabi.authorizationobjects.Permission;
 import com.intuit.wasabi.assignmentobjects.SegmentationProfile;
 import com.intuit.wasabi.assignmentobjects.User;
 import com.intuit.wasabi.exceptions.AssignmentNotFoundException;
+import com.intuit.wasabi.exceptions.AuthenticationException;
 import com.intuit.wasabi.experimentobjects.Application;
 import com.intuit.wasabi.experimentobjects.Bucket;
 import com.intuit.wasabi.experimentobjects.Bucket.Label;
@@ -42,15 +47,23 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static java.nio.charset.Charset.forName;
+import static org.apache.commons.codec.binary.Base64.encodeBase64;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AssignmentsResourceTest {
+
+    private static final String USERPASS = new String(encodeBase64("admin@example.com:admin01".getBytes(forName("UTF-8"))), forName("UTF-8"));
+    private static final String AUTHHEADER = "Basic: " + USERPASS;
+    private static final UserInfo.Username USER = UserInfo.Username.valueOf("admin@example.com");
 
     private final Boolean CREATE = true;
     private final Boolean FORCE_IN_EXPERIMENT = true;
@@ -77,6 +90,8 @@ public class AssignmentsResourceTest {
     private Map<String, Object> submittedData;
     @Mock
     private Page.Name pageName;
+    @Mock
+    private Authorization authorization;
     private AssignmentsResource resource;
     private Application.Name applicationName = Application.Name.valueOf("testApp");
     private Experiment.Label experimentLabel = Experiment.Label.valueOf("testExp");
@@ -86,7 +101,7 @@ public class AssignmentsResourceTest {
 
     @Before
     public void setUp() {
-        resource = new AssignmentsResource(assignments, new HttpHeader("application-name"));
+        resource = new AssignmentsResource(assignments, new HttpHeader("application-name"), authorization);
     }
 
     @Test
@@ -217,4 +232,29 @@ public class AssignmentsResourceTest {
     public void getAssignmentsQueueLength() throws Exception {
         assertThat(resource.getAssignmentsQueueLength().getStatus(), is(HttpStatus.SC_OK));
     }
+    
+    @Test
+    public void getAssignmentsQueueDetails() throws Exception {
+        assertThat(resource.getAssignmentsQueueDetails().getStatus(), is(HttpStatus.SC_OK));
+    }
+    
+    @Test
+    public void flushMessages() throws Exception {
+        when(authorization.getUser(AUTHHEADER)).thenReturn(USER);
+        assertThat(resource.flushMessages(AUTHHEADER).getStatus(), is(HttpStatus.SC_OK));
+    }
+    
+    @Test
+    public void flushMessagesNotSuperAdmin() throws Exception {
+        // fewer allowed experiments
+        when(authorization.getUser(AUTHHEADER)).thenReturn(USER);
+        //this throw is so that only the allowed (TESTAPP) experiments get returned
+        doThrow(AuthenticationException.class).when(authorization).checkSuperAdmin(USER);
+        try {
+            resource.flushMessages(AUTHHEADER);
+            fail();
+        } catch (AuthenticationException ignored) {
+        }        
+    }
+
 }

--- a/modules/api/src/test/java/com/intuit/wasabi/api/AssignmentsResourceTest.java
+++ b/modules/api/src/test/java/com/intuit/wasabi/api/AssignmentsResourceTest.java
@@ -19,9 +19,7 @@ import com.intuit.wasabi.assignment.Assignments;
 import com.intuit.wasabi.assignmentobjects.Assignment;
 import com.intuit.wasabi.assignmentobjects.Assignment.Status;
 import com.intuit.wasabi.authenticationobjects.UserInfo;
-import com.intuit.wasabi.authenticationobjects.UserInfo.Username;
 import com.intuit.wasabi.authorization.Authorization;
-import com.intuit.wasabi.authorizationobjects.Permission;
 import com.intuit.wasabi.assignmentobjects.SegmentationProfile;
 import com.intuit.wasabi.assignmentobjects.User;
 import com.intuit.wasabi.exceptions.AssignmentNotFoundException;
@@ -43,7 +41,11 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+
+import java.net.InetAddress;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -51,8 +53,7 @@ import static java.nio.charset.Charset.forName;
 import static org.apache.commons.codec.binary.Base64.encodeBase64;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.doThrow;
@@ -64,6 +65,9 @@ public class AssignmentsResourceTest {
     private static final String USERPASS = new String(encodeBase64("admin@example.com:admin01".getBytes(forName("UTF-8"))), forName("UTF-8"));
     private static final String AUTHHEADER = "Basic: " + USERPASS;
     private static final UserInfo.Username USER = UserInfo.Username.valueOf("admin@example.com");
+    private static final String HOST_IP = "hostIP";
+    private static final String RULE_CACHE = "ruleCache";
+    private static final String QUEUE_SIZE = "queueSize";
 
     private final Boolean CREATE = true;
     private final Boolean FORCE_IN_EXPERIMENT = true;
@@ -235,13 +239,28 @@ public class AssignmentsResourceTest {
     
     @Test
     public void getAssignmentsQueueDetails() throws Exception {
+        Map<String, Object> queueDetailsMap = new HashMap<String, Object>();
+        try {
+            queueDetailsMap.put(HOST_IP, InetAddress.getLocalHost().getHostAddress());
+        } catch (Exception e) {
+            // ignore
+        }
+        Map<String, Object> testIngestionExecutorMap = new HashMap<String, Object>();
+        testIngestionExecutorMap.put(QUEUE_SIZE, new Integer(0));
+        Map<String, Object> ruleCacheMap = new HashMap<String, Object>();
+        ruleCacheMap.put(QUEUE_SIZE, new Integer(0));
+        queueDetailsMap.put(RULE_CACHE, ruleCacheMap);
+        queueDetailsMap.put("test", testIngestionExecutorMap);
         assertThat(resource.getAssignmentsQueueDetails().getStatus(), is(HttpStatus.SC_OK));
+        when(assignments.queuesDetails()).thenReturn(queueDetailsMap);
+        Response response = resource.getAssignmentsQueueDetails();
+        assertEquals(queueDetailsMap, response.getEntity());
     }
     
     @Test
     public void flushMessages() throws Exception {
         when(authorization.getUser(AUTHHEADER)).thenReturn(USER);
-        assertThat(resource.flushMessages(AUTHHEADER).getStatus(), is(HttpStatus.SC_OK));
+        assertThat(resource.flushMessages(AUTHHEADER).getStatus(), is(HttpStatus.SC_NO_CONTENT));
     }
     
     @Test

--- a/modules/assignment-objects/src/main/java/com/intuit/wasabi/assignmentobjects/AssignmentEnvelopePayload.java
+++ b/modules/assignment-objects/src/main/java/com/intuit/wasabi/assignmentobjects/AssignmentEnvelopePayload.java
@@ -322,7 +322,7 @@ public class AssignmentEnvelopePayload implements EnvelopePayload {
     @Override
     public String toJson() {
         JSONObject assignmentJson = new JSONObject();
-        assignmentJson.put("userID", userID.toString());
+        assignmentJson.put("userID", userID != null ? userID.toString() : "");
         assignmentJson.put("applicationName", applicationName != null ? applicationName.toString() : "");
         assignmentJson.put("experimentLabel", experimentLabel != null ? experimentLabel.toString() : "");
         assignmentJson.put("context", context != null ? context.toString() : "PROD");

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/AssignmentIngestionExecutor.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/AssignmentIngestionExecutor.java
@@ -1,5 +1,8 @@
 package com.intuit.wasabi.assignment;
 
+import java.util.Map;
+import java.util.concurrent.Future;
+
 import com.intuit.wasabi.assignmentobjects.AssignmentEnvelopePayload;
 
 public interface AssignmentIngestionExecutor {
@@ -8,15 +11,29 @@ public interface AssignmentIngestionExecutor {
 	 * This method ingests what is contained in the {@link com.intuit.wasabi.assignmentobjects.AssignmentEnvelopePayload} to real time data ingestion system.
 	 * 
 	 * @param assignmentEnvelopePayload
+     * @return a Future representing pending completion of the task
 	 */
-	public void execute(AssignmentEnvelopePayload assignmentEnvelopePayload);
+	public Future<?> execute(AssignmentEnvelopePayload assignmentEnvelopePayload);
 	
     /**
      * Number of elements in the ingestion queue.
      *
      * @return number of elements in the queue
      */
+	@Deprecated
     public int queueLength();
+
+    /**
+     * Details of ingestion queue.
+     *
+     * @return details of ingestion queue
+     */
+    public Map<String, Object> queueDetails();
+    
+    /**
+     * Flush all messages from ingestion memory queue including active and the ones waiting. These messages should be persisted before flushed.
+     */
+    public void flushMessages();
 
     /**
      * Name of the ingestion executor.

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/Assignments.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/Assignments.java
@@ -47,7 +47,18 @@ public interface Assignments {
      *
      * @return Map of number of elements each queue
      */
+    @Deprecated
     Map<String, Integer> queuesLength();
+
+    /**
+     * @return Details of the queues in rule cache and ingestion executors.
+     */
+    Map<String, Object> queuesDetails();
+    
+    /**
+     * Flush all active and queued messages in ThreadPoolExecutor to persistent store.
+     */
+    void flushMessages();
 
     /**
      * Gets the Assignment for one user for an specific experiment.

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
@@ -87,7 +87,6 @@ import com.intuit.wasabi.repository.CassandraRepository;
 import com.intuit.wasabi.repository.ExperimentRepository;
 import com.intuit.wasabi.repository.MutexRepository;
 import com.intuit.wasabi.repository.cassandra.impl.ExperimentRuleCacheUpdateEnvelope;
-import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
 
 /**
  * Assignments implementation
@@ -178,7 +177,7 @@ public class AssignmentsImpl implements Assignments {
                            final AssignmentDecorator assignmentDecorator,
                            final @Named("ruleCache.threadPool") ThreadPoolExecutor ruleCacheExecutor,
                            final EventLog eventLog)
-            throws IOException, ConnectionException {
+            throws IOException {
         super();
         try {
             hostIP = InetAddress.getLocalHost().getHostAddress();

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
@@ -1105,15 +1105,15 @@ public class AssignmentsImpl implements Assignments {
 
     @Override
     public Map<String, Object> queuesDetails() {
-        Map<String, Object> queueLengthMap = new HashMap<String, Object>();
-        queueLengthMap.put(HOST_IP, hostIP);
+        Map<String, Object> queueDetailsMap = new HashMap<String, Object>();
+        queueDetailsMap.put(HOST_IP, hostIP);
         Map<String, Object> ruleCacheMap = new HashMap<String, Object>();
         ruleCacheMap.put(QUEUE_SIZE, new Integer(this.ruleCacheExecutor.getQueue().size()));
-        queueLengthMap.put(RULE_CACHE, ruleCacheMap);
+        queueDetailsMap.put(RULE_CACHE, ruleCacheMap);
         for (String name : executors.keySet()) {
-            queueLengthMap.put(name.toLowerCase(), executors.get(name).queueDetails());
+            queueDetailsMap.put(name.toLowerCase(), executors.get(name).queueDetails());
         }
-        return queueLengthMap;
+        return queueDetailsMap;
     }
     
     public void flushMessages() {

--- a/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
+++ b/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
@@ -38,7 +38,6 @@ import com.intuit.wasabi.repository.AssignmentsRepository;
 import com.intuit.wasabi.repository.ExperimentRepository;
 import com.intuit.wasabi.repository.MutexRepository;
 import com.intuit.wasabi.repository.cassandra.impl.ExperimentRuleCacheUpdateEnvelope;
-import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -96,7 +95,7 @@ public class AssignmentsImplTest {
     private AssignmentsImpl assignmentsImpl;
 
     @Before
-    public void setup() throws IOException, ConnectionException {
+    public void setup() throws IOException {
         Map<String, AssignmentIngestionExecutor> executors = new HashMap<String, AssignmentIngestionExecutor>();
         executors.put(TEST_INGESTION_EXECUTOR_NAME, ingestionExecutor);
         this.assignmentsImpl = new AssignmentsImpl(executors,
@@ -161,7 +160,7 @@ public class AssignmentsImplTest {
     }
 
     @Test
-    public void testGetSingleAssignmentNullAssignmentExperimentInDraftState() throws IOException, ConnectionException {
+    public void testGetSingleAssignmentNullAssignmentExperimentInDraftState() throws IOException {
         AssignmentsImpl assignmentsImpl = spy(new AssignmentsImpl(new HashMap<String, AssignmentIngestionExecutor>(),
                 experimentRepository, assignmentsRepository,
                 mutexRepository, ruleCache, pages, priorities, assignmentDecorator, threadPoolExecutor,
@@ -267,7 +266,7 @@ public class AssignmentsImplTest {
     }
 
     @Test
-    public void testGetSingleAssignmentNullAssignmentExperimentNoProfileMatch() throws IOException, ConnectionException {
+    public void testGetSingleAssignmentNullAssignmentExperimentNoProfileMatch() throws IOException {
         AssignmentsImpl assignmentsImpl = spy(new AssignmentsImpl(new HashMap<String, AssignmentIngestionExecutor>(),
                 experimentRepository, assignmentsRepository,
                 mutexRepository, ruleCache, pages, priorities, assignmentDecorator, threadPoolExecutor, eventLog));
@@ -322,7 +321,7 @@ public class AssignmentsImplTest {
     }
 
     @Test(expected = AssertionError.class)
-    public void testGetSingleAssignmentProfileMatchAssertNewAssignment() throws IOException, ConnectionException {
+    public void testGetSingleAssignmentProfileMatchAssertNewAssignment() throws IOException {
         AssignmentsImpl assignmentsImpl = spy(new AssignmentsImpl(new HashMap<String, AssignmentIngestionExecutor>(),
                 experimentRepository, assignmentsRepository,
                 mutexRepository, ruleCache, pages, priorities, assignmentDecorator, threadPoolExecutor, eventLog));
@@ -352,7 +351,7 @@ public class AssignmentsImplTest {
     }
 
     @Test
-    public void testGetSingleAssignmentSuccess() throws IOException, ConnectionException {
+    public void testGetSingleAssignmentSuccess() throws IOException {
         AssignmentsImpl assignmentsImpl = spy(new AssignmentsImpl(new HashMap<String, AssignmentIngestionExecutor>(),
                 experimentRepository, assignmentsRepository,
                 mutexRepository, ruleCache, pages, priorities, assignmentDecorator, threadPoolExecutor, eventLog));
@@ -378,7 +377,7 @@ public class AssignmentsImplTest {
 
 
     @Test
-    public void testGetAssignmentNullAssignment() throws IOException, ConnectionException {
+    public void testGetAssignmentNullAssignment() throws IOException {
         Application.Name appName = Application.Name.valueOf("testApp");
         User.ID userID = User.ID.valueOf("test");
         Experiment.Label label = Experiment.Label.valueOf("test");
@@ -402,7 +401,7 @@ public class AssignmentsImplTest {
     }
 
     @Test
-    public void testGetAssignment() throws IOException, ConnectionException {
+    public void testGetAssignment() throws IOException {
         Application.Name appName = Application.Name.valueOf("testApp");
         User.ID userID = User.ID.valueOf("test");
         Experiment.Label label = Experiment.Label.valueOf("test");
@@ -431,7 +430,7 @@ public class AssignmentsImplTest {
     // FIXME:
 //    @Ignore("FIXME:refactor-core")
 //    @Test
-//    public void checkContextInSegmentation() throws IOException, ConnectionException {
+//    public void checkContextInSegmentation() throws IOException {
 //
 //        //Create a segmentation profile
 //        SegmentationProfile segmentationProfile = SegmentationProfile.newInstance().build();
@@ -491,7 +490,7 @@ public class AssignmentsImplTest {
     // FIXME:
 //    @Ignore("FIXME:refactor-core")
 //    @Test
-//    public void getAssignment_test_1() throws IOException, ConnectionException {
+//    public void getAssignment_test_1() throws IOException {
 //
 //        cassandraAssignments = null; //new AssignmentsImpl(cassandraRepository, assignmentsRepository, mutexRepository, random,
 ////                ruleCache, pages, priorities, assignmentDBEnvelopeProvider, assignmentWebEnvelopeProvider, null, // FIXME
@@ -554,7 +553,7 @@ public class AssignmentsImplTest {
     // FIXME:
 //    @Ignore("FIXME:refactor-core")
 //    @Test
-//    public void getAssignment_test_2() throws IOException, ConnectionException {
+//    public void getAssignment_test_2() throws IOException {
 //        cassandraAssignments = null; //new AssignmentsImpl(cassandraRepository, assignmentsRepository, mutexRepository, random,
 ////                ruleCache, pages, priorities, assignmentDBEnvelopeProvider, assignmentWebEnvelopeProvider, null, // FIXME
 ////                decisionEngineScheme, decisionEngineHost, decisionEnginePath,
@@ -582,7 +581,7 @@ public class AssignmentsImplTest {
 //    }
 
     @Test
-    public void getAssignment_test_3() throws IOException, ConnectionException {
+    public void getAssignment_test_3() throws IOException {
         final Calendar c = Calendar.getInstance();
         c.setTime(new Date());
         c.add(Calendar.DATE, -1);
@@ -810,7 +809,7 @@ public class AssignmentsImplTest {
     */
 
     @Test
-    public void getAssignment_test_4() throws IOException, ConnectionException {
+    public void getAssignment_test_4() throws IOException {
         final Calendar c = Calendar.getInstance();
         c.setTime(new Date());
         c.add(Calendar.DATE, -1);
@@ -941,7 +940,7 @@ public class AssignmentsImplTest {
     }
 
     @Test
-    public void doBatchAssignmentsTest() throws IOException, ConnectionException {
+    public void doBatchAssignmentsTest() throws IOException {
         final Calendar c = Calendar.getInstance();
         c.setTime(new Date());
         c.add(Calendar.DATE, -1);
@@ -1070,7 +1069,7 @@ public class AssignmentsImplTest {
     }
 
     @Test
-    public void doPageAssignmentsTest() throws IOException, ConnectionException {
+    public void doPageAssignmentsTest() throws IOException {
         final Calendar c = Calendar.getInstance();
         c.setTime(new Date());
         c.add(Calendar.DATE, -1);
@@ -1203,7 +1202,7 @@ public class AssignmentsImplTest {
     }
 
     @Test
-    public void putAssignment_test() throws IOException, ConnectionException {
+    public void putAssignment_test() throws IOException {
         final Calendar c = Calendar.getInstance();
         c.setTime(new Date());
         final Experiment.Label expLabel = Experiment.Label.valueOf("testExp");
@@ -1310,7 +1309,7 @@ public class AssignmentsImplTest {
     // FIXME:
 //    @Ignore("FIXME:refactor-core")
 //    @Test
-//    public void URIConstructorTest() throws IOException, URISyntaxException, ConnectionException {
+//    public void URIConstructorTest() throws IOException, URISyntaxException {
 //
 //        cassandraAssignments = null; //new AssignmentsImpl(cassandraRepository, assignmentsRepository, mutexRepository, random,
 ////                ruleCache, pages, priorities, assignmentDBEnvelopeProvider, assignmentWebEnvelopeProvider, null, //FIXME

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/AssignmentsRepository.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/AssignmentsRepository.java
@@ -149,10 +149,11 @@ public interface AssignmentsRepository {
     /**
      * Push assignment to staging
      *
+     * @param type type of assignment to be staged
      * @param exception Exception
      * @param data      Assignment Data to be pushed to staging
      */
-    void pushAssignmentToStaging(String exception, String data);
+    void pushAssignmentToStaging(String type, String exception, String data);
 
     /**
      * Increments the bucket assignments counter up by 1 if countUp is true

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/accessor/StagingAccessor.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/accessor/StagingAccessor.java
@@ -25,6 +25,6 @@ import com.datastax.driver.mapping.annotations.Query;
  */
 @Accessor
 public interface StagingAccessor {
-    @Query("insert into staging(time, type, exep , msg) values(now(), 'ASSIGNMENT', ? , ?)")
-    ResultSet insertBy(String exception, String message);
+    @Query("insert into staging(time, type, exep , msg) values(now(), ?, ? , ?)")
+    ResultSet insertBy(String type, String exception, String message);
 }

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepository.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepository.java
@@ -853,9 +853,9 @@ public class CassandraAssignmentsRepository implements AssignmentsRepository {
 
     @Override
     @Timed
-    public void pushAssignmentToStaging(String exception, String data) {
+    public void pushAssignmentToStaging(String type, String exception, String data) {
         try{
-            stagingAccessor.insertBy(exception, data);
+            stagingAccessor.insertBy(type, exception, data);
         } catch (WriteTimeoutException | UnavailableException | NoHostAvailableException e) {
             throw new RepositoryException("Could not push the assignment to staging", e);
         }

--- a/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepositoryTest.java
+++ b/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepositoryTest.java
@@ -1047,18 +1047,18 @@ public class CassandraAssignmentsRepositoryTest {
 
     @Test
     public void testPushAssignmentToStaging(){
-        repository.pushAssignmentToStaging("string1", "string2");
+        repository.pushAssignmentToStaging("type", "string1", "string2");
         verify(stagingAccessor, times(1))
-                .insertBy(eq("string1"), eq("string2"));
+                .insertBy(eq("type"), eq("string1"), eq("string2"));
     }
 
     @Test
     public void testPushAssignmentToStagingrWriteException(){
         doThrow(WriteTimeoutException.class).when(stagingAccessor)
-                .insertBy(eq("string1"), eq("string2"));
+                .insertBy(eq("type"), eq("string1"), eq("string2"));
         thrown.expect(RepositoryException.class);
         thrown.expectMessage("Could not push the assignment to staging");
-        repository.pushAssignmentToStaging("string1", "string2");
+        repository.pushAssignmentToStaging("type", "string1", "string2");
     }
 
     @Test


### PR DESCRIPTION
This enhancement is to:
1) Fix memory/resource exhaustion issue due to Ingestion Executor's
queue keep growing when active threads are blocked.
2) Added new admin REST API to flush and persist active & pending
messages in the queue and another API to return detailed of the queue
status.