### PR TITLE
Add Access-Control-Max-Age and fix duplicate CORS

### DIFF
--- a/modules/api/src/main/java/com/intuit/wasabi/api/ApiModule.java
+++ b/modules/api/src/main/java/com/intuit/wasabi/api/ApiModule.java
@@ -69,6 +69,8 @@ public class ApiModule extends AbstractModule {
                 .toInstance(getProperty("default.time.zone", properties, "yyyy-MM-dd HH:mm:ss"));
         bind(String.class).annotatedWith(named("default.time.format"))
                 .toInstance(getProperty("default.time.format", properties, "yyyy-MM-dd HH:mm:ss"));
+        bind(String.class).annotatedWith(named("access.control.max.age.delta.seconds"))
+                .toInstance(getProperty("access.control.max.age.delta.seconds", properties));
 
         bind(AuthorizedExperimentGetter.class).in(SINGLETON);
         bind(HealthCheckRegistry.class).in(SINGLETON);

--- a/modules/api/src/main/java/com/intuit/wasabi/api/HttpHeader.java
+++ b/modules/api/src/main/java/com/intuit/wasabi/api/HttpHeader.java
@@ -30,12 +30,13 @@ import static javax.ws.rs.core.Response.status;
 public class HttpHeader {
 
     private final String applicationName;
+    private final String deltaSeconds;
     private final CacheControl cacheControl;
 
     @Inject
-    public HttpHeader(final @Named("application.id") String applicationName) {
+    public HttpHeader(final @Named("application.id") String applicationName, final @Named("access.control.max.age.delta.seconds") String deltaSeconds) {
         this.applicationName = applicationName;
-
+        this.deltaSeconds = deltaSeconds;
         cacheControl = new CacheControl();
 
         cacheControl.setPrivate(TRUE);
@@ -59,8 +60,9 @@ public class HttpHeader {
                 .cacheControl(cacheControl)
                 .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                 .header(ACCESS_CONTROL_ALLOW_HEADERS, "Authorization,X-Forwarded-For,Accept-Language,Content-Type")
-                .header(ACCESS_CONTROL_ALLOW_METHODS, "GET,POST,OPTIONS")
-                .header(ACCESS_CONTROL_REQUEST_METHOD, "GET,POST,OPTIONS")
+                .header(ACCESS_CONTROL_ALLOW_METHODS, "GET,POST,PUT,DELETE,OPTIONS")
+                .header(ACCESS_CONTROL_REQUEST_METHOD, "GET,POST,PUT,DELETE,OPTIONS")
+                .header(ACCESS_CONTROL_MAX_AGE, deltaSeconds)
                 .header("X-Application-Id", applicationName);
     }
 }

--- a/modules/api/src/main/java/com/intuit/wasabi/api/SimpleCORSResponseFilter.java
+++ b/modules/api/src/main/java/com/intuit/wasabi/api/SimpleCORSResponseFilter.java
@@ -25,9 +25,14 @@ import org.slf4j.Logger;
 import javax.ws.rs.core.Response;
 
 import static org.slf4j.LoggerFactory.getLogger;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static com.google.common.net.HttpHeaders.*;
+
+import java.util.Objects;
 
 public class SimpleCORSResponseFilter implements ContainerResponseFilter {
 
+    private static final String X_APPLICATION_ID = "X-Application-Id";
     private final static Logger LOGGER = getLogger(SimpleCORSResponseFilter.class);
     private final String applicationName;
     private final String deltaSeconds;
@@ -46,20 +51,24 @@ public class SimpleCORSResponseFilter implements ContainerResponseFilter {
         Response.ResponseBuilder response = Response.fromResponse(containerResponse.getResponse());
 
         if ("OPTIONS".equals(containerRequest.getMethod())) {
-            
-            response.status(204)
-                    .header("Access-Control-Allow-Origin", "*")
-                    .header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-                    .header("Access-Control-Request-Method", "GET, POST, PUT, DELETE, OPTIONS")
-                    .header("Access-Control-Max-Age", deltaSeconds)
-                    .header("Content-Type", "application/json")
-                    .header("X-Application-Id", applicationName)
-                    .entity("");
+            if (Objects.isNull(containerResponse.getHttpHeaders().get(ACCESS_CONTROL_ALLOW_ORIGIN)))
+                response.header(ACCESS_CONTROL_ALLOW_ORIGIN, "*");
+            if (Objects.isNull(containerResponse.getHttpHeaders().get(ACCESS_CONTROL_ALLOW_METHODS)))
+                response.header(ACCESS_CONTROL_ALLOW_METHODS, "GET, POST, PUT, DELETE, OPTIONS");
+            if (Objects.isNull(containerResponse.getHttpHeaders().get(ACCESS_CONTROL_REQUEST_METHOD)))
+                response.header(ACCESS_CONTROL_REQUEST_METHOD, "GET, POST, PUT, DELETE, OPTIONS");
+            if (Objects.isNull(containerResponse.getHttpHeaders().get(ACCESS_CONTROL_MAX_AGE)))
+                response.header(ACCESS_CONTROL_MAX_AGE, deltaSeconds);
+            if (Objects.isNull(containerResponse.getHttpHeaders().get(CONTENT_TYPE)))
+                response.header(CONTENT_TYPE, APPLICATION_JSON);
+            if (Objects.isNull(containerResponse.getHttpHeaders().get(X_APPLICATION_ID)))
+                response.header(X_APPLICATION_ID, applicationName);
+            response.entity("");
 
-            String requestHeader = containerRequest.getHeaderValue("Access-Control-Request-Headers");
+            String requestHeader = containerRequest.getHeaderValue(ACCESS_CONTROL_REQUEST_HEADERS);
 
             if (requestHeader != null) {
-                response.header("Access-Control-Allow-Headers", requestHeader);
+                response.header(ACCESS_CONTROL_ALLOW_HEADERS, requestHeader);
             }
         }
 

--- a/modules/api/src/main/java/com/intuit/wasabi/api/SimpleCORSResponseFilter.java
+++ b/modules/api/src/main/java/com/intuit/wasabi/api/SimpleCORSResponseFilter.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package com.intuit.wasabi.api;
 
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import com.sun.jersey.spi.container.ContainerRequest;
 import com.sun.jersey.spi.container.ContainerResponse;
 import com.sun.jersey.spi.container.ContainerResponseFilter;
@@ -27,9 +29,14 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class SimpleCORSResponseFilter implements ContainerResponseFilter {
 
     private final static Logger LOGGER = getLogger(SimpleCORSResponseFilter.class);
+    private final String applicationName;
+    private final String deltaSeconds;
 
-    public SimpleCORSResponseFilter() {
+    @Inject
+    public SimpleCORSResponseFilter(final @Named("application.id") String applicationName, final @Named("access.control.max.age.delta.seconds") String deltaSeconds) {
         LOGGER.info("Instantiated response filter {}", getClass().getName());
+        this.applicationName = applicationName;
+        this.deltaSeconds = deltaSeconds;
     }
 
     @Override
@@ -39,11 +46,14 @@ public class SimpleCORSResponseFilter implements ContainerResponseFilter {
         Response.ResponseBuilder response = Response.fromResponse(containerResponse.getResponse());
 
         if ("OPTIONS".equals(containerRequest.getMethod())) {
-
+            
             response.status(204)
                     .header("Access-Control-Allow-Origin", "*")
                     .header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+                    .header("Access-Control-Request-Method", "GET, POST, PUT, DELETE, OPTIONS")
+                    .header("Access-Control-Max-Age", deltaSeconds)
                     .header("Content-Type", "application/json")
+                    .header("X-Application-Id", applicationName)
                     .entity("");
 
             String requestHeader = containerRequest.getHeaderValue("Access-Control-Request-Headers");

--- a/modules/api/src/main/java/com/intuit/wasabi/api/SimpleCORSResponseFilter.java
+++ b/modules/api/src/main/java/com/intuit/wasabi/api/SimpleCORSResponseFilter.java
@@ -20,9 +20,11 @@ import com.google.inject.name.Named;
 import com.sun.jersey.spi.container.ContainerRequest;
 import com.sun.jersey.spi.container.ContainerResponse;
 import com.sun.jersey.spi.container.ContainerResponseFilter;
+
 import org.slf4j.Logger;
 
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 import static org.slf4j.LoggerFactory.getLogger;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -47,10 +49,11 @@ public class SimpleCORSResponseFilter implements ContainerResponseFilter {
     @Override
     public ContainerResponse filter(ContainerRequest containerRequest, ContainerResponse containerResponse) {
         LOGGER.trace("CORS filter called for request: {}", containerRequest);
-
+        
         Response.ResponseBuilder response = Response.fromResponse(containerResponse.getResponse());
 
         if ("OPTIONS".equals(containerRequest.getMethod())) {
+            response.status(Status.NO_CONTENT);
             if (Objects.isNull(containerResponse.getHttpHeaders().get(ACCESS_CONTROL_ALLOW_ORIGIN)))
                 response.header(ACCESS_CONTROL_ALLOW_ORIGIN, "*");
             if (Objects.isNull(containerResponse.getHttpHeaders().get(ACCESS_CONTROL_ALLOW_METHODS)))
@@ -63,7 +66,7 @@ public class SimpleCORSResponseFilter implements ContainerResponseFilter {
                 response.header(CONTENT_TYPE, APPLICATION_JSON);
             if (Objects.isNull(containerResponse.getHttpHeaders().get(X_APPLICATION_ID)))
                 response.header(X_APPLICATION_ID, applicationName);
-            response.entity("");
+            response.entity(null);
 
             String requestHeader = containerRequest.getHeaderValue(ACCESS_CONTROL_REQUEST_HEADERS);
 

--- a/modules/api/src/main/resources/api.properties
+++ b/modules/api/src/main/resources/api.properties
@@ -16,3 +16,4 @@
 application.id:${application.name}-${scmBranch}-${buildNumber}-${timestamp}
 default.time.zone:${default.time.zone}
 default.time.format:${default.time.format}
+access.control.max.age.delta.seconds:${access.control.max.age.delta.seconds}

--- a/modules/api/src/test/java/com/intuit/wasabi/api/AssignmentsResourceTest.java
+++ b/modules/api/src/test/java/com/intuit/wasabi/api/AssignmentsResourceTest.java
@@ -86,7 +86,7 @@ public class AssignmentsResourceTest {
 
     @Before
     public void setUp() {
-        resource = new AssignmentsResource(assignments, new HttpHeader("application-name"));
+        resource = new AssignmentsResource(assignments, new HttpHeader("application-name", "600"));
     }
 
     @Test

--- a/modules/api/src/test/java/com/intuit/wasabi/api/AuditLogResourceTest.java
+++ b/modules/api/src/test/java/com/intuit/wasabi/api/AuditLogResourceTest.java
@@ -49,7 +49,7 @@ public class AuditLogResourceTest {
         AuditLog al = mock(AuditLogImpl.class);
         Authorization auth = mock(Authorization.class);
         List<AuditLogEntry> list = new ArrayList<>();
-        AuditLogResource lr = new AuditLogResource(al, auth, new HttpHeader("MyApp-???"), new PaginationHelper<>(new AuditLogEntryFilter(), new AuditLogEntryComparator()));
+        AuditLogResource lr = new AuditLogResource(al, auth, new HttpHeader("MyApp-???", "600"), new PaginationHelper<>(new AuditLogEntryFilter(), new AuditLogEntryComparator()));
 
         Mockito.when(al.getAuditLogs()).thenReturn(list);
         Response r = lr.getCompleteLogs("", 1, 10, "", "", null);
@@ -78,7 +78,7 @@ public class AuditLogResourceTest {
         Application.Name appName = Application.Name.valueOf("TestApp");
         Authorization auth = mock(Authorization.class);
         List<AuditLogEntry> list = new ArrayList<>();
-        AuditLogResource lr = new AuditLogResource(al, auth, new HttpHeader("MyApp-???"), new PaginationHelper<>(new AuditLogEntryFilter(), new AuditLogEntryComparator()));
+        AuditLogResource lr = new AuditLogResource(al, auth, new HttpHeader("MyApp-???", "600"), new PaginationHelper<>(new AuditLogEntryFilter(), new AuditLogEntryComparator()));
 
         Mockito.when(al.getAuditLogs(appName)).thenReturn(list);
         Response r = lr.getLogs("", appName, 1, 10, "", "", null);

--- a/modules/api/src/test/java/com/intuit/wasabi/api/AuthenticationResourceTest.java
+++ b/modules/api/src/test/java/com/intuit/wasabi/api/AuthenticationResourceTest.java
@@ -44,7 +44,7 @@ public class AuthenticationResourceTest {
 
     @Before
     public void setup() {
-        authenticationResource = new AuthenticationResource(authentication, new HttpHeader("application-name"));
+        authenticationResource = new AuthenticationResource(authentication, new HttpHeader("application-name", "600"));
     }
 
     @Test

--- a/modules/api/src/test/java/com/intuit/wasabi/api/AuthorizationResourceTest.java
+++ b/modules/api/src/test/java/com/intuit/wasabi/api/AuthorizationResourceTest.java
@@ -67,7 +67,7 @@ public class AuthorizationResourceTest {
     @Test
     public void getRolePermissions() throws Exception {
 
-        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???"));
+        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???", "600"));
 
         HashMap<String,Object> result = new HashMap<>();
 
@@ -80,7 +80,7 @@ public class AuthorizationResourceTest {
     @Test
     public void getUserPermissions() throws Exception {
 
-        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???"));
+        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???", "600"));
 
         when(authorization.getUser(AUTHHEADER)).thenReturn(USER);
         UserPermissions userPermissions = UserPermissions.newInstance(TESTAPP,
@@ -104,7 +104,7 @@ public class AuthorizationResourceTest {
     @Test
     public void getUserAppPermissions() throws Exception {
 
-        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???"));
+        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???", "600"));
 
         when(authorization.getUser(AUTHHEADER)).thenReturn(USER);
         UserPermissions userPermissions = UserPermissions.newInstance(TESTAPP,
@@ -124,7 +124,7 @@ public class AuthorizationResourceTest {
     @Test
     public void assignUserRoles() throws Exception {
 
-        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???"));
+        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???", "600"));
 
         UserRole userRole = UserRole.newInstance(TESTAPP,Role.ADMIN).withUserID(USER).build();
         UserRole userRole1 = UserRole.newInstance(TESTAPP2, Role.READWRITE).withUserID(TESTUSER).build();
@@ -165,7 +165,7 @@ public class AuthorizationResourceTest {
     @Test
     public void updateUserRoles() throws Exception {
 
-        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???"));
+        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???", "600"));
 
         UserRole userRole = UserRole.newInstance(TESTAPP,Role.ADMIN).withUserID(USER).build();
         UserRole userRole1 = UserRole.newInstance(TESTAPP2, Role.READWRITE).withUserID(TESTUSER).build();
@@ -206,7 +206,7 @@ public class AuthorizationResourceTest {
     @Test
     public void getUserRole() throws Exception {
 
-        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???"));
+        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???", "600"));
 
         UserRole userRole = UserRole.newInstance(TESTAPP,Role.ADMIN).withUserID(USER).build();
         UserRole userRole1 = UserRole.newInstance(TESTAPP2, Role.READWRITE).withUserID(USER).build();
@@ -238,7 +238,7 @@ public class AuthorizationResourceTest {
     @Test
     public void deleteUserRoles() throws Exception {
 
-        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???"));
+        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???", "600"));
 
         when(authorization.getUser(AUTHHEADER)).thenReturn(USER);
 
@@ -249,7 +249,7 @@ public class AuthorizationResourceTest {
     @Test
     public void getApplicationUsersByRole() throws Exception {
 
-        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???"));
+        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???", "600"));
 
         UserRole userRole = UserRole.newInstance(TESTAPP,Role.ADMIN).withUserID(USER).build();
         UserRole userRole1 = UserRole.newInstance(TESTAPP2, Role.READWRITE).withUserID(USER).build();
@@ -266,7 +266,7 @@ public class AuthorizationResourceTest {
 
     @Test
     public void testGetUserList() throws Exception {
-        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???"));
+        AuthorizationResource authorizationResource = new AuthorizationResource(authorization, new HttpHeader("jaba-???", "600"));
 
         UserRole userRole = UserRole.newInstance(TESTAPP, Role.ADMIN).withUserID(USER).build();
         UserRoleList userRoleList = new UserRoleList();

--- a/modules/api/src/test/java/com/intuit/wasabi/api/EmailResourceTest.java
+++ b/modules/api/src/test/java/com/intuit/wasabi/api/EmailResourceTest.java
@@ -28,7 +28,7 @@ public class EmailResourceTest {
 
     @Before
     public void setUp() {
-        resource = new EmailResource(mock, new HttpHeader("apbcc"));
+        resource = new EmailResource(mock, new HttpHeader("apbcc", "600"));
     }
 
     @Test

--- a/modules/api/src/test/java/com/intuit/wasabi/api/EventsResourceTest.java
+++ b/modules/api/src/test/java/com/intuit/wasabi/api/EventsResourceTest.java
@@ -57,7 +57,7 @@ public class EventsResourceTest {
 
     @Before
     public void setUp() throws Exception {
-        resource = new EventsResource(events, new HttpHeader("App-???"));
+        resource = new EventsResource(events, new HttpHeader("App-???", "600"));
     }
 
     @Test

--- a/modules/api/src/test/java/com/intuit/wasabi/api/ExperimentsResourceTest.java
+++ b/modules/api/src/test/java/com/intuit/wasabi/api/ExperimentsResourceTest.java
@@ -156,7 +156,7 @@ public class ExperimentsResourceTest {
                 .build();
 
         experimentsResource = new ExperimentsResource(experiments, eventsExport, assignments,
-                authorization, buckets, mutex, pages, priorities, favorites, "US/New York", "YYYY-mm-DD", new HttpHeader("MyApp-???"), paginationHelper);
+                authorization, buckets, mutex, pages, priorities, favorites, "US/New York", "YYYY-mm-DD", new HttpHeader("MyApp-???", "600"), paginationHelper);
         doReturn(Collections.emptyList()).when(favorites).getFavorites(Mockito.any());
     }
 

--- a/modules/api/src/test/java/com/intuit/wasabi/api/FavoritesResourceTest.java
+++ b/modules/api/src/test/java/com/intuit/wasabi/api/FavoritesResourceTest.java
@@ -47,7 +47,7 @@ public class FavoritesResourceTest {
     @Mock
     private Authorization authorization;
 
-    private HttpHeader httpHeader = new HttpHeader("TestApplication");
+    private HttpHeader httpHeader = new HttpHeader("TestApplication", "600");
     private FavoritesResource favoritesResource;
     private Experiment testExperiment;
     private List<Experiment.ID> expectedFavoriteList;

--- a/modules/api/src/test/java/com/intuit/wasabi/api/HttpHeaderTest.java
+++ b/modules/api/src/test/java/com/intuit/wasabi/api/HttpHeaderTest.java
@@ -46,7 +46,7 @@ public class HttpHeaderTest {
 
     @Before
     public void before() {
-        httpHeader = new HttpHeader("name");
+        httpHeader = new HttpHeader("name", "600");
     }
 
     @Test
@@ -62,13 +62,14 @@ public class HttpHeaderTest {
 
         MultivaluedMap<String, Object> metaData = response.getMetadata();
 
-        assertThat(metaData.size(), is(6));
+        assertThat(metaData.size(), is(7));
         assertThat(metaData.get(HttpHeaders.CACHE_CONTROL), hasItem(CACHE_CONTROL));
         assertThat(metaData.get(ACCESS_CONTROL_ALLOW_ORIGIN), hasItem("*"));
         assertThat(metaData.get(ACCESS_CONTROL_ALLOW_HEADERS),
                 hasItem("Authorization,X-Forwarded-For,Accept-Language,Content-Type"));
-        assertThat(metaData.get(ACCESS_CONTROL_ALLOW_METHODS), hasItem("GET,POST,OPTIONS"));
-        assertThat(metaData.get(ACCESS_CONTROL_REQUEST_METHOD), hasItem("GET,POST,OPTIONS"));
+        assertThat(metaData.get(ACCESS_CONTROL_ALLOW_METHODS), hasItem("GET,POST,PUT,DELETE,OPTIONS"));
+        assertThat(metaData.get(ACCESS_CONTROL_REQUEST_METHOD), hasItem("GET,POST,PUT,DELETE,OPTIONS"));
+        assertThat(metaData.get(ACCESS_CONTROL_MAX_AGE), hasItem("600"));
         assertThat(metaData.get("X-Application-Id"), hasItem("name"));
         assertThat(response.getEntity(), is(nullValue()));
     }
@@ -81,13 +82,14 @@ public class HttpHeaderTest {
 
         MultivaluedMap<String, Object> metaData = response.getMetadata();
 
-        assertThat(metaData.size(), is(6));
+        assertThat(metaData.size(), is(7));
         assertThat(metaData.get(HttpHeaders.CACHE_CONTROL), hasItem(CACHE_CONTROL));
         assertThat(metaData.get(ACCESS_CONTROL_ALLOW_ORIGIN), hasItem("*"));
         assertThat(metaData.get(ACCESS_CONTROL_ALLOW_HEADERS),
                 hasItem("Authorization,X-Forwarded-For,Accept-Language,Content-Type"));
-        assertThat(metaData.get(ACCESS_CONTROL_ALLOW_METHODS), hasItem("GET,POST,OPTIONS"));
-        assertThat(metaData.get(ACCESS_CONTROL_REQUEST_METHOD), hasItem("GET,POST,OPTIONS"));
+        assertThat(metaData.get(ACCESS_CONTROL_ALLOW_METHODS), hasItem("GET,POST,PUT,DELETE,OPTIONS"));
+        assertThat(metaData.get(ACCESS_CONTROL_REQUEST_METHOD), hasItem("GET,POST,PUT,DELETE,OPTIONS"));
+        assertThat(metaData.get(ACCESS_CONTROL_MAX_AGE), hasItem("600"));
         assertThat(metaData.get("X-Application-Id"), hasItem("name"));
         assertThat(response.getEntity(), is(nullValue()));
     }

--- a/modules/api/src/test/java/com/intuit/wasabi/api/PingResourceTest.java
+++ b/modules/api/src/test/java/com/intuit/wasabi/api/PingResourceTest.java
@@ -41,7 +41,7 @@ public class PingResourceTest {
 
     @Before
     public void setup() {
-        resouce = new PingResource(healthChecks, new HttpHeader(version));
+        resouce = new PingResource(healthChecks, new HttpHeader(version, "600"));
     }
 
     @Test

--- a/modules/api/src/test/java/com/intuit/wasabi/api/SimpleCORSResponseFilterTest.java
+++ b/modules/api/src/test/java/com/intuit/wasabi/api/SimpleCORSResponseFilterTest.java
@@ -26,7 +26,6 @@ import com.sun.jersey.core.header.OutBoundHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
-import static com.google.common.net.HttpHeaders.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 

--- a/modules/api/src/test/java/com/intuit/wasabi/api/SimpleCORSResponseFilterTest.java
+++ b/modules/api/src/test/java/com/intuit/wasabi/api/SimpleCORSResponseFilterTest.java
@@ -22,10 +22,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
+import com.sun.jersey.core.header.OutBoundHeaders;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
-import static org.junit.Assert.assertNotNull;
+import static com.google.common.net.HttpHeaders.*;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -47,10 +49,19 @@ public class SimpleCORSResponseFilterTest {
 	public void filter() {
 		Response response = Response.ok().build();
 		when(containerResponse.getResponse()).thenReturn(response);
+        when(containerResponse.getStatus()).thenReturn(Status.OK.getStatusCode());
+        when(containerResponse.getHttpHeaders()).thenReturn(new OutBoundHeaders());
 		when(containerRequest.getMethod()).thenReturn("OPTIONS");
 		when(containerRequest.getHeaderValue("Access-Control-Request-Headers")).thenReturn("foo");
 
-		assertNotNull(filter.filter(containerRequest, containerResponse));
+		ContainerResponse returnedContainerResponse = filter.filter(containerRequest, containerResponse);
+		assertNotNull(returnedContainerResponse);
+		assertEquals(Status.OK.getStatusCode(), returnedContainerResponse.getStatus());
+		
+		response = Response.status(Status.NOT_FOUND.getStatusCode()).build();
+        when(containerResponse.getStatus()).thenReturn(Status.NOT_FOUND.getStatusCode());
+		returnedContainerResponse = filter.filter(containerRequest, containerResponse);
+        assertEquals(Status.NOT_FOUND.getStatusCode(), returnedContainerResponse.getStatus());
 	}
 
 }

--- a/modules/api/src/test/java/com/intuit/wasabi/api/SimpleCORSResponseFilterTest.java
+++ b/modules/api/src/test/java/com/intuit/wasabi/api/SimpleCORSResponseFilterTest.java
@@ -40,13 +40,14 @@ public class SimpleCORSResponseFilterTest {
 
     @Before
     public void setup() {
-    	filter = new SimpleCORSResponseFilter();
+    	filter = new SimpleCORSResponseFilter("name", "600");
     }
 
 	@Test
 	public void filter() {
 		Response response = Response.ok().build();
 		when(containerResponse.getResponse()).thenReturn(response);
+		when(containerRequest.getMethod()).thenReturn("OPTIONS");
 		when(containerRequest.getHeaderValue("Access-Control-Request-Headers")).thenReturn("foo");
 
 		assertNotNull(filter.filter(containerRequest, containerResponse));

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@ http://www.w3.org/2001/XMLSchema-instance">
     <properties>
         <default.time.zone>UTC</default.time.zone>
         <default.time.format>yyyy-MM-dd HH:mm:ss</default.time.format>
+        <access.control.max.age.delta.seconds>600</access.control.max.age.delta.seconds>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@ http://www.w3.org/2001/XMLSchema-instance">
     <properties>
         <default.time.zone>UTC</default.time.zone>
         <default.time.format>yyyy-MM-dd HH:mm:ss</default.time.format>
-        <access.control.max.age.delta.seconds>600</access.control.max.age.delta.seconds>
+        <access.control.max.age.delta.seconds>86400</access.control.max.age.delta.seconds>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
This request is to do the followings:

1) Add Access-Control-Max-Age response header so client can cache preflight request.
2) Fix duplicate CORS headers when call fails for OPTIONS request.