### PR TITLE
Replaced string literals with constant variables: Enables compile time checking of usages

### DIFF
--- a/modules/api/src/main/java/com/intuit/wasabi/api/ApiAnnotations.java
+++ b/modules/api/src/main/java/com/intuit/wasabi/api/ApiAnnotations.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright 2016 Intuit
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.intuit.wasabi.api;
+
+public class ApiAnnotations {
+    public static final String APPLICATION_ID = "application.id";
+    public static final String DEFAULT_TIME_ZONE = "default.time.zone";
+    public static final String DEFAULT_TIME_FORMAT = "default.time.format";
+    public static final String ACCESS_CONTROL_MAX_AGE_DELTA_SECONDS = "access.control.max.age.delta.seconds";
+}

--- a/modules/api/src/main/java/com/intuit/wasabi/api/ApiAnnotations.java
+++ b/modules/api/src/main/java/com/intuit/wasabi/api/ApiAnnotations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2016 Intuit
+ * Copyright 2017 Intuit
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/api/src/main/java/com/intuit/wasabi/api/ApiModule.java
+++ b/modules/api/src/main/java/com/intuit/wasabi/api/ApiModule.java
@@ -63,13 +63,13 @@ public class ApiModule extends AbstractModule {
 
         Properties properties = create(PROPERTY_NAME, ApiModule.class);
 
-        bind(String.class).annotatedWith(named("application.id"))
+        bind(String.class).annotatedWith(named(ApiAnnotations.APPLICATION_ID))
                 .toInstance(getProperty("application.id", properties));
-        bind(String.class).annotatedWith(named("default.time.zone"))
-                .toInstance(getProperty("default.time.zone", properties, "yyyy-MM-dd HH:mm:ss"));
-        bind(String.class).annotatedWith(named("default.time.format"))
+        bind(String.class).annotatedWith(named(ApiAnnotations.DEFAULT_TIME_ZONE))
+                .toInstance(getProperty("default.time.zone", properties, "UTC"));
+        bind(String.class).annotatedWith(named(ApiAnnotations.DEFAULT_TIME_FORMAT))
                 .toInstance(getProperty("default.time.format", properties, "yyyy-MM-dd HH:mm:ss"));
-        bind(String.class).annotatedWith(named("access.control.max.age.delta.seconds"))
+        bind(String.class).annotatedWith(named(ApiAnnotations.ACCESS_CONTROL_MAX_AGE_DELTA_SECONDS))
                 .toInstance(getProperty("access.control.max.age.delta.seconds", properties));
 
         bind(AuthorizedExperimentGetter.class).in(SINGLETON);

--- a/modules/api/src/main/java/com/intuit/wasabi/api/ExperimentsResource.java
+++ b/modules/api/src/main/java/com/intuit/wasabi/api/ExperimentsResource.java
@@ -132,8 +132,8 @@ public class ExperimentsResource {
     ExperimentsResource(final Experiments experiments, final EventsExport export, final Assignments assignments,
                         final Authorization authorization, final Buckets buckets, final Mutex mutex,
                         final Pages pages, final Priorities priorities, final Favorites favorites,
-                        final @Named("default.time.zone") String defaultTimezone,
-                        final @Named("default.time.format") String defaultTimeFormat,
+                        final @Named(ApiAnnotations.DEFAULT_TIME_ZONE) String defaultTimezone,
+                        final @Named(ApiAnnotations.DEFAULT_TIME_FORMAT) String defaultTimeFormat,
                         final HttpHeader httpHeader, final PaginationHelper<Experiment> experimentPaginationHelper
     ) {
         this.experiments = experiments;

--- a/modules/api/src/main/java/com/intuit/wasabi/api/HttpHeader.java
+++ b/modules/api/src/main/java/com/intuit/wasabi/api/HttpHeader.java
@@ -34,7 +34,7 @@ public class HttpHeader {
     private final CacheControl cacheControl;
 
     @Inject
-    public HttpHeader(final @Named("application.id") String applicationName, final @Named("access.control.max.age.delta.seconds") String deltaSeconds) {
+    public HttpHeader(final @Named(ApiAnnotations.APPLICATION_ID) String applicationName, final @Named(ApiAnnotations.ACCESS_CONTROL_MAX_AGE_DELTA_SECONDS) String deltaSeconds) {
         this.applicationName = applicationName;
         this.deltaSeconds = deltaSeconds;
         cacheControl = new CacheControl();

--- a/modules/api/src/main/java/com/intuit/wasabi/api/SimpleCORSResponseFilter.java
+++ b/modules/api/src/main/java/com/intuit/wasabi/api/SimpleCORSResponseFilter.java
@@ -40,7 +40,8 @@ public class SimpleCORSResponseFilter implements ContainerResponseFilter {
     private final String deltaSeconds;
 
     @Inject
-    public SimpleCORSResponseFilter(final @Named("application.id") String applicationName, final @Named("access.control.max.age.delta.seconds") String deltaSeconds) {
+    public SimpleCORSResponseFilter(final @Named(ApiAnnotations.APPLICATION_ID) String applicationName,
+            final @Named(ApiAnnotations.ACCESS_CONTROL_MAX_AGE_DELTA_SECONDS) String deltaSeconds) {
         LOGGER.info("Instantiated response filter {}", getClass().getName());
         this.applicationName = applicationName;
         this.deltaSeconds = deltaSeconds;


### PR DESCRIPTION
String literals were being used for named annotations. They ran the risk of not being consistent in their usages due to typos or otherwise. To enable strict compile-time checking, it is suggested to use constants to store these literals and use the constants everywhere.