### PR TITLE
Feature/ehcache memory fix : Wasabi failed to start

### DIFF
--- a/modules/assignment/src/main/resources/ehcache.xml
+++ b/modules/assignment/src/main/resources/ehcache.xml
@@ -20,7 +20,7 @@
          updateCheck="true"
          monitoring="autodetect"
          dynamicConfig="true"
-         maxBytesLocalHeap="2G"
+         maxBytesLocalHeap="${assignment.metadata.cache.maxBytesLocalHeap}"
 >
 
     <defaultCache maxEntriesLocalHeap="0" eternal="true" />

--- a/modules/main/src/main/env/service/run
+++ b/modules/main/src/main/env/service/run
@@ -23,8 +23,12 @@ MAIN=${application.main}
 DAEMON=\${WASABI_DAEMON:-${application.daemon.enable}}
 CONSOLE_LOG=\${LOG_DIR}/${application.name}-console.log
 CLASSPATH=\${HOME_DIR}/conf:\${HOME_DIR}/lib/${application.name}-all.jar
+HEAP_SIZE=${application.heapsize}
 
-JAVA_OPTIONS="-server\
+JAVA_OPTIONS="
+  -Xms\${HEAP_SIZE}\
+  -Xmx\${HEAP_SIZE}\
+  -server\
   ${application.instrument}\
   ${application.monitor}\
   -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=\${LOG_DIR}/java_$$.hprof\

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,8 @@ http://www.w3.org/2001/XMLSchema-instance">
         <application.name>${project.name}-${project.version}-${application.profile}</application.name>
         <application.version>1.0</application.version>
         <application.home>/usr/local/${application.name}</application.home>
+        <application.heapsize>256m</application.heapsize>
+        <assignment.metadata.cache.maxBytesLocalHeap>128M</assignment.metadata.cache.maxBytesLocalHeap>
 
         <jacoco.version>0.7.2.201409121644</jacoco.version>
         <jacoco.destFile>${basedir}/../target/jacoco.exec</jacoco.destFile>


### PR DESCRIPTION
With the recent introduction of EHCache for caching assignment metadata, the wasabi application was failing to start on the develop branch. It was due to EHCache configured with a default "maxBytesLocalHeap" property of 2GB where as the default heap size on the JVM (if not explicitly specified) is 256MB. There is a check in the EHCache configuration code where it checks this property against the total size of the heap and if it is configured greater than the heap size, it throws the following exception:

CacheManager configuration: You've assigned more memory to the on-heap than the VM can sustain, please adjust your -Xmx setting accordingly

These changes allow configuring the application heap size and the "maxBytesLocalHeap" property at the build level so that they can be set as per requirement.

The changes have been successfully built and tested.