### PR TITLE
UI defaults to same host it was served on for backend API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,18 +305,6 @@ The runtime logs can be accessed executing the following command in a another sh
 % grunt build
 ```
 
-> Edit Gruntfile.js with the following change to the apiHostBaseUrlValue value, since you would be running the
-Wasabi server on localhost.
-
-```javascript
-development: {
-  constants: {
-    supportEmail: 'you@example.com',
-    apiHostBaseUrlValue: 'http://localhost:8080/api/v1'
-  }
-}
-```
-
 ```bash
 % grunt serve
 ```

--- a/bin/wasabi.sh
+++ b/bin/wasabi.sh
@@ -255,8 +255,6 @@ package() {
 
   # FIXME: move to modules/ui/build.sh
   version=$(fromPom . build project.version)
-  # FIXME: server ip
-  server="http://localhost:8080"
   home=$(fromPom ./modules/main build application.home)
   name=wasabi-ui #$(fromPom main build application.name)
   api_name=$(fromPom ./modules/main build application.name)
@@ -302,7 +300,6 @@ package() {
     echo Getting merged plugins.js file and plugins directory; \
     cp dist/scripts/plugins.js target/app/scripts/plugins.js; \
     cp -R dist/plugins target/app; \
-    sed -i '' -e "s|http://localhost:8080|${server}|g" target/constants.json 2>/dev/null; \
     sed -i '' -e "s|VERSIONLOC|${version}|g" target/app/index.html 2>/dev/null; \
     #(cd target; npm install; bower install --no-optional; grunt clean); \
     (cd target; grunt clean); \

--- a/modules/ui/README.md
+++ b/modules/ui/README.md
@@ -32,3 +32,30 @@ Install Yo, Grunt, Bower, and Compass
 ```
 % grunt serve
 ```
+
+### Run the Production Version of the UI
+
+If you want to test how the UI runs from the combined and minified files (which you would generally use
+when you go to Production), you will need to do the following (after you have done the build steps above):
+
+Edit constants.json with the following change to the apiHostBaseUrlValue value, since you would be running the
+Wasabi server on localhost:8080, but the UI will be served on localhost:9000.  This is then produced in the
+dist/scripts/config.js file, which causes the backend API URLs to start with that value, and hit your docker container:
+
+```javascript
+{
+    supportEmail: 'you@example.com',
+    apiHostBaseUrlValue: 'http://localhost:8080/api/v1'
+}
+```
+
+Then:
+
+```
+% grunt serve:dist
+```
+
+This will build the UI into the dist folder and then start a web server, serving the UI from that folder on
+http://localhost:9000 .
+
+

--- a/modules/ui/app/scripts/services/ConfigFactory.js
+++ b/modules/ui/app/scripts/services/ConfigFactory.js
@@ -3,6 +3,10 @@
 angular.module('wasabi.services').factory('ConfigFactory', ['apiHostBaseUrlValue', function(apiHostBaseUrlValue) {
     return {
         baseUrl: function() {
+            if (apiHostBaseUrlValue === 'DEFAULT') {
+                // We want to pull the URL to use as the backend URL from where the UI was served.
+                return window.location.protocol + '//' + window.location.host + '/api/v1';
+            }
             return apiHostBaseUrlValue;
         },
 

--- a/modules/ui/constants.json
+++ b/modules/ui/constants.json
@@ -1,4 +1,4 @@
 {
     "supportEmail": "",
-    "apiHostBaseUrlValue": "http://localhost:8080/api/v1"
+    "apiHostBaseUrlValue": "DEFAULT"
 }


### PR DESCRIPTION
Changed so that if the server URL that was used to load the UI is the same as the server URL of the backend, then you don’t need to change constants.json or config.js.  Instead, the UI gets the URL of the backend from the URL of the app in the browser environment.  If they need to be different, e.g., if you are running the backend in docker on localhost:8080, but you are running the UI in the foreground using “grunt serve”, then you will need to set the correct value in constants.json.