### PR TITLE
Feature/code coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,7 +466,7 @@ http://www.w3.org/2001/XMLSchema-instance">
                                 <goal>report</goal>
                             </goals>
                             <configuration>
-                                <dataFile>${project.build.directory}/target/jacoco.exec</dataFile>
+                                <dataFile>${project.build.directory}/jacoco.exec</dataFile>
                                 <outputDirectory>${basedir}/target/</outputDirectory>
                             </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@ http://www.w3.org/2001/XMLSchema-instance">
         <assignment.metadata.cache.maxBytesLocalHeap>128M</assignment.metadata.cache.maxBytesLocalHeap>
 
         <jacoco.version>0.7.2.201409121644</jacoco.version>
-        <jacoco.destFile>${basedir}/modules/target/jacoco.exec</jacoco.destFile>
+        <jacoco.destFile>${basedir}/target/jacoco.exec</jacoco.destFile>
 
         <http.proxy.host>http://insert.your.proxy.host.here</http.proxy.host>
         <http.proxy.port>80</http.proxy.port>
@@ -447,7 +447,7 @@ http://www.w3.org/2001/XMLSchema-instance">
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.version}</version>
                 <configuration>
-                    <dataFile>${basedir}/modules/target/jacoco.exec</dataFile>
+                    <dataFile>${basedir}/target/jacoco.exec</dataFile>
                     <excludes>
                         <exclude>com/intuit/wasabi/tests/**/*.class</exclude>
                     </excludes>
@@ -467,7 +467,7 @@ http://www.w3.org/2001/XMLSchema-instance">
                             </goals>
                             <configuration>
                                 <dataFile>${project.build.directory}/target/jacoco.exec</dataFile>
-                                <outputDirectory>${basedir}/modules/target/</outputDirectory>
+                                <outputDirectory>${basedir}/target/</outputDirectory>
                             </configuration>
                     </execution>
                 </executions>
@@ -494,7 +494,7 @@ http://www.w3.org/2001/XMLSchema-instance">
                 <configuration>
                     <repoToken>${env.coveralls_repo_token}</repoToken>
                     <jacocoReports>
-                        <jacocoReport>${basedir}/modules/target/jacoco.xml</jacocoReport>
+                        <jacocoReport>${basedir}/target/jacoco.xml</jacocoReport>
                     </jacocoReports>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Standardized jacoco.exec and jacoco.xml files to be writtern to [WS]/modules/\<moduleName]>/target/jacoco.\*, instead of [WS]/modules/\<moduleName\>/modules/target/jacoco.\*

This is to make sure both Travis CI/Coveralls and Jenkins/Sonar find jacoco files successfully