### PR TITLE
Fix bug that superadmin menu choice is shown to admins

### DIFF
--- a/modules/ui/app/scripts/services/UtilitiesFactory.js
+++ b/modules/ui/app/scripts/services/UtilitiesFactory.js
@@ -43,6 +43,7 @@ angular.module('wasabi.services').factory('UtilitiesFactory', ['Session', '$stat
                     this.hideTopLevelTab('Plugins', false);
                     this.hideTopLevelTabMenuChoice('Logs', false);
                     this.hideTopLevelTabMenuChoice('Feedback', !Session.isSuperadmin);
+                    this.hideTopLevelTabMenuChoice('Superadmins', !Session.isSuperadmin);
                     this.hideTopLevelTab('Tools', false);
                 }
                 else {
@@ -51,6 +52,7 @@ angular.module('wasabi.services').factory('UtilitiesFactory', ['Session', '$stat
                     this.hideTopLevelTab('Plugins');
                     this.hideTopLevelTabMenuChoice('Logs');
                     this.hideTopLevelTabMenuChoice('Feedback', true);
+                    this.hideTopLevelTabMenuChoice('Superadmins', true);
                     this.hideTopLevelTab('Tools', true);
                 }
             },


### PR DESCRIPTION
Fixing bug that if you are not a superadmin, but you are an admin, you see the Superadmins menu choice.  It doesn’t work, because the API is still access controlled.