### PR TITLE
Null dereference check on EventEnvelopePayload toJson utility

### DIFF
--- a/modules/assignment-objects/src/main/java/com/intuit/wasabi/assignmentobjects/AssignmentEnvelopePayload.java
+++ b/modules/assignment-objects/src/main/java/com/intuit/wasabi/assignmentobjects/AssignmentEnvelopePayload.java
@@ -329,9 +329,9 @@ public class AssignmentEnvelopePayload implements EnvelopePayload {
         assignmentJson.put("createAssignment", createAssignment);
         assignmentJson.put("putAssignment", putAssignment);
         assignmentJson.put("ignoreSamplingPercent", ignoreSamplingPercent);
-        assignmentJson.put("segmentationProfile", segmentationProfile != null ?
-                segmentationProfile.getProfile() != null ?
-                        segmentationProfile.getProfile().toString() : "" : "");
+        assignmentJson.put("segmentationProfile",
+                segmentationProfile != null && segmentationProfile.getProfile() != null ?
+                        segmentationProfile.getProfile().toString() : "");
         assignmentJson.put("experimentID", experimentID != null ? experimentID.toString() : "");
         assignmentJson.put("pageName", pageName != null ? pageName.toString() : "");
         assignmentJson.put("assignmentStatus", assignmentStatus != null ?

--- a/modules/event-objects/src/main/java/com/intuit/wasabi/eventobjects/EventEnvelopePayload.java
+++ b/modules/event-objects/src/main/java/com/intuit/wasabi/eventobjects/EventEnvelopePayload.java
@@ -88,18 +88,27 @@ public class EventEnvelopePayload implements EnvelopePayload {
         JSONObject eventJson = new JSONObject();
 
         eventJson.put("messageType", MessageType.EVENT.toString());
-        eventJson.put("applicationName", applicationName.toString());
-        eventJson.put("experimentLabel", experimentLabel.toString());
-        eventJson.put("userID", assignment.getUserID().toString());
-        eventJson.put("bucketLabel", assignment.getBucketLabel().toString());
+        eventJson.put("applicationName", applicationName != null ? applicationName.toString(): "");
+        eventJson.put("experimentLabel", experimentLabel != null ? experimentLabel.toString(): "");
+        eventJson.put("userID",
+                assignment != null && assignment.getUserID() != null ? assignment.getUserID().toString(): "");
+        eventJson.put("bucketLabel",
+                assignment != null && assignment.getBucketLabel() != null ? assignment.getBucketLabel().toString(): "");
         eventJson.put("time_uuid", makeUUID().toString());
-        eventJson.put("experimentID", assignment.getExperimentID().toString());
-        eventJson.put("context", assignment.getContext().toString());
-        eventJson.put("epochTimestamp", event.getTimestamp().getTime());
-        eventJson.put("eventType", event.getType() + "");
-        eventJson.put("eventName", event.getName() + "");
-        eventJson.put("eventPayload", event.getPayload());
-        eventJson.put("value", event.getValue());
+        eventJson.put("experimentID",
+                assignment != null && assignment.getExperimentID() != null ? assignment.getExperimentID().toString(): "");
+        eventJson.put("context",
+                assignment != null && assignment.getContext() != null ? assignment.getContext().toString(): "");
+        eventJson.put("epochTimestamp",
+                event != null && event.getTimestamp() != null ? event.getTimestamp().getTime(): "");
+        eventJson.put("eventType",
+                event != null && event.getType() != null ? event.getType().toString(): "");
+        eventJson.put("eventName",
+                event != null && event.getName() != null ? event.getName().toString(): "");
+        eventJson.put("eventPayload",
+                event != null ? event.getPayload(): "");
+        eventJson.put("value",
+                event != null ? event.getValue(): "");
 
         return eventJson.toString();
     }

--- a/modules/event-objects/src/main/java/com/intuit/wasabi/eventobjects/EventEnvelopePayload.java
+++ b/modules/event-objects/src/main/java/com/intuit/wasabi/eventobjects/EventEnvelopePayload.java
@@ -103,8 +103,8 @@ public class EventEnvelopePayload implements EnvelopePayload {
                 assignment != null && assignment.getContext() != null ? assignment.getContext().toString(): null);
         eventJson.put("epochTimestamp",
                 event != null && event.getTimestamp() != null ? event.getTimestamp().getTime(): null);
-        eventJson.put("eventType", event != null && event.getType() != null ? event.getType() + "": "null");
-        eventJson.put("eventName", event != null && event.getName() != null ? event.getName() + "": "null");
+        eventJson.put("eventType", event != null ? event.getType() + "": "null");
+        eventJson.put("eventName", event != null ? event.getName() + "": "null");
         eventJson.put("eventPayload", event != null ? event.getPayload(): null);
         eventJson.put("value", event != null ? event.getValue(): null);
 

--- a/modules/event-objects/src/main/java/com/intuit/wasabi/eventobjects/EventEnvelopePayload.java
+++ b/modules/event-objects/src/main/java/com/intuit/wasabi/eventobjects/EventEnvelopePayload.java
@@ -88,27 +88,25 @@ public class EventEnvelopePayload implements EnvelopePayload {
         JSONObject eventJson = new JSONObject();
 
         eventJson.put("messageType", MessageType.EVENT.toString());
-        eventJson.put("applicationName", applicationName != null ? applicationName.toString(): "");
-        eventJson.put("experimentLabel", experimentLabel != null ? experimentLabel.toString(): "");
+        eventJson.put("applicationName", applicationName != null ? applicationName.toString(): null);
+        eventJson.put("experimentLabel", experimentLabel != null ? experimentLabel.toString(): null);
         eventJson.put("userID",
-                assignment != null && assignment.getUserID() != null ? assignment.getUserID().toString(): "");
+                assignment != null && assignment.getUserID() != null ? assignment.getUserID().toString(): null);
         eventJson.put("bucketLabel",
-                assignment != null && assignment.getBucketLabel() != null ? assignment.getBucketLabel().toString(): "");
+                assignment != null && assignment.getBucketLabel() != null ?
+                        assignment.getBucketLabel().toString(): null);
         eventJson.put("time_uuid", makeUUID().toString());
         eventJson.put("experimentID",
-                assignment != null && assignment.getExperimentID() != null ? assignment.getExperimentID().toString(): "");
+                assignment != null && assignment.getExperimentID() != null ?
+                        assignment.getExperimentID().toString(): null);
         eventJson.put("context",
-                assignment != null && assignment.getContext() != null ? assignment.getContext().toString(): "");
+                assignment != null && assignment.getContext() != null ? assignment.getContext().toString(): null);
         eventJson.put("epochTimestamp",
-                event != null && event.getTimestamp() != null ? event.getTimestamp().getTime(): "");
-        eventJson.put("eventType",
-                event != null && event.getType() != null ? event.getType().toString(): "");
-        eventJson.put("eventName",
-                event != null && event.getName() != null ? event.getName().toString(): "");
-        eventJson.put("eventPayload",
-                event != null ? event.getPayload(): "");
-        eventJson.put("value",
-                event != null ? event.getValue(): "");
+                event != null && event.getTimestamp() != null ? event.getTimestamp().getTime(): null);
+        eventJson.put("eventType", event != null && event.getType() != null ? event.getType() + "": "null");
+        eventJson.put("eventName", event != null && event.getName() != null ? event.getName() + "": "null");
+        eventJson.put("eventPayload", event != null ? event.getPayload(): null);
+        eventJson.put("value", event != null ? event.getValue(): null);
 
         return eventJson.toString();
     }


### PR DESCRIPTION
We were seeing null pointer exceptions on the export DB internally on Wasabi's intuit extension which were caused by unsafe dereferencing of null objects while using the toJson utility on the event envelope. This change addresses the fix.

There is a parallel PR on wasabi intuit as well.