### PR TITLE
Facilitate working with remote storage hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,33 @@ Server: Jetty(9.3.z-SNAPSHOT)
 
 Congratulations! You are the proud owner of a newly minted Wasabi instance. :)
 
+### Running Wasabi with remote storage
+
+##### Set Mysql and Cassandra credentials
+* Modify /pom.xml to set the values that apply to your environment
+
+##### Download Cassandra migration tool https://oss.sonatype.org/content/repositories/public/com/builtamont/cassandra-migration/0.9/cassandra-migration-0.9-jar-with-dependencies.jar
+
+##### Set up your environment variables
+* Set location of the migration tool
+```bash
+export CASSANDRA_MIGRATION=/location/of/cassandra-migration-0.9-jar-with-dependencies.jar
+```
+* Set location of migration scripts within your project
+```bash
+export MIGRATION_SCRIPT=/location/of/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration
+```
+
+##### Set up Cassandra tables
+```bash
+CQLSH_VERSION=<version> CQLSH_USERNAME=<username> CQLSH_PASSWORD=<pwd> CQLSH_HOST=<host> bin/docker/migration.sh
+```
+
+##### Run Wasabi with env variables for remote storage hosts
+```bash
+MYSQL_HOST=<mysql_host> NODE_HOST=<cassandra_host> ./bin/wasabi.sh start:wasabi
+```
+
 #### Troubleshooting
 
 * While starting Wasabi, if you see an error when the docker containers are starting up, you could do the following:
@@ -207,13 +234,13 @@ The following developer resources are available:
 ```bash
 % ./bin/wasabi.sh resource:api
 ```
-  
+
 > Javadoc
 
 ```bash
 % ./bin/wasabi.sh resource:doc
 ```
-  
+
 > Wasabi UI
 
 ```bash
@@ -256,15 +283,15 @@ Further, there are a number of additional wasabi.sh options available you should
 
 ```bash
 % ./bin/wasabi.sh --help
-  
+
   usage: wasabi.sh [options] [commands]
-  
+
   options:
     -e | --endpoint [ host:port ]          : api endpoint; default: localhost:8080
     -v | --verify [ true | false ]         : verify installation configuration; default: false
     -s | --sleep [ sleep-time ]            : sleep/wait time in seconds; default: 30
     -h | --help                            : help message
-  
+
   commands:
     bootstrap                              : install dependencies
     build                                  : build project

--- a/bin/container.sh
+++ b/bin/container.sh
@@ -147,7 +147,7 @@ start_wasabi() {
   CASSANDRA_CONTAINER_NAME=${CASSANDRA_CONTAINER:-${project}-cassandra}
   IS_CONTAINER=`docker inspect -f {{.State.Running}} $CASSANDRA_CONTAINER_NAME`
   if [ "$IS_CONTAINER" = true ] ; then
-    wcip=$(docker inspect --format "{{ .NetworkSettings.Networks.${docker_network}.IPAddress }}" ${project}-cassandra)
+    wcip=$(docker inspect --format "{{ .NetworkSettings.Networks.${docker_network}.IPAddress }}" ${CASSANDRA_CONTAINER_NAME})
   elif [ -z ${NODE_HOST} ]; then
     echo "[ERROR] Cassandra container must be running or NODE_HOST environment variable must be set"
     exit 1;
@@ -158,7 +158,7 @@ start_wasabi() {
   MYSQL_CONTAINER_NAME=${MYSQL_CONTAINER:-${project}-mysql}
   IS_CONTAINER=`docker inspect -f {{.State.Running}} $MYSQL_CONTAINER_NAME`
   if [ "$IS_CONTAINER" = true ] ; then
-    wmip=$(docker inspect --format "{{ .NetworkSettings.Networks.${docker_network}.IPAddress }}" ${project}-mysql)
+    wmip=$(docker inspect --format "{{ .NetworkSettings.Networks.${docker_network}.IPAddress }}" ${MYSQL_CONTAINER_NAME})
   elif [ -z ${MYSQL_HOST} ]; then
     echo "[ERROR] Mysql container must be running or MYSQL_HOST environment variable must be set"
     exit 1;

--- a/bin/docker/create_keyspace.sh
+++ b/bin/docker/create_keyspace.sh
@@ -3,17 +3,17 @@
 # The cqlsh is a duplicate of the the existing cqlsh==5.0.3 with hard coded default protocol version to 3.
 # the original cqlsh have hard coded protocol version of 4.
 # the current [2016-10-01] version of server spec is [Cassandra 2.1.15 | CQL spec 3.2.1 | Native protocol v3]
-echo "/usr/local/bin/cqlsh " \
-     "--cqlversion=\"3.2.1\" "\
+echo "cqlsh " \
+     "--cqlversion=\"${CQLSH_VERSION:-3.2.1}\" "\
      "-e \"CREATE KEYSPACE IF NOT EXISTS ${CASSANDRA_KEYSPACE_PREFIX:-wasabi}_experiments WITH replication = {'class' : 'SimpleStrategy', 'replication_factor' : ${CASSANDRA_REPLICATION:-1}};\"" \
      "--username=${CQLSH_USERNAME}" \
      "--password=\"${CQLSH_PASSWORD}\"" \
      "${CQLSH_HOST:-localhost}" \
      "${CASSANDRA_PORT:-9042}"
 
-while ! nc -w 1 -z ${CQLSH_HOST-localhost} ${CASSANDRA_PORT:-9042}; do sleep 0.1; done
+while ! nc -w 1 -z ${CQLSH_HOST:-localhost} ${CASSANDRA_PORT:-9042}; do sleep 0.1; done
 
-/usr/local/bin/cqlsh --cqlversion="3.2.1" \
+cqlsh --cqlversion="${CQLSH_VERSION:-3.2.1}" \
     -e "CREATE KEYSPACE IF NOT EXISTS ${CASSANDRA_KEYSPACE_PREFIX:-wasabi}_experiments WITH replication = {'class' : 'SimpleStrategy', 'replication_factor' : ${CASSANDRA_REPLICATION:-1}};" \
     --username=${CQLSH_USERNAME} \
     --password="${CQLSH_PASSWORD}" \

--- a/bin/docker/schema_migration.sh
+++ b/bin/docker/schema_migration.sh
@@ -8,7 +8,7 @@ echo "java -jar -Dcassandra.migration.keyspace.name=${CASSANDRA_KEYSPACE:-wasabi
     -Dcassandra.migration.cluster.contactpoints=${CQLSH_HOST:-localhost} \
     ${CASSANDRA_MIGRATION:-/wasabi/cassandra-migration.jar} migrate"
 
-while ! nc -w 1 -z ${CQLSH_HOST-localhost} ${CASSANDRA_PORT:-9042}; do sleep 0.1; done
+while ! nc -w 1 -z ${CQLSH_HOST:-localhost} ${CASSANDRA_PORT:-9042}; do sleep 0.1; done
 
 java -jar -Dcassandra.migration.keyspace.name=${CASSANDRA_KEYSPACE:-wasabi_experiments} \
     -Dcassandra.migration.cluster.port=${CASSANDRA_PORT:-9042} \

--- a/modules/cassandra-datastax/src/main/java/com/intuit/wasabi/cassandra/datastax/CassandraDriver.java
+++ b/modules/cassandra-datastax/src/main/java/com/intuit/wasabi/cassandra/datastax/CassandraDriver.java
@@ -65,6 +65,18 @@ public interface CassandraDriver extends Closeable {
         String getKeyspaceName();
 
         /**
+         * Returns Cassandra username
+         * @return username
+         */
+        String getUsername();
+
+        /**
+         * Returns Cassandra password
+         * @return password
+         */
+        String getPassword();
+
+        /**
          * Returns Cassandra port
          * @return port number
          */

--- a/modules/cassandra-datastax/src/main/java/com/intuit/wasabi/cassandra/datastax/DefaultCassandraDriver.java
+++ b/modules/cassandra-datastax/src/main/java/com/intuit/wasabi/cassandra/datastax/DefaultCassandraDriver.java
@@ -54,6 +54,7 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -92,6 +93,12 @@ public class DefaultCassandraDriver implements CassandraDriver {
                 builder.addContactPoints(nodes.toArray(new String[nodes.size()]))
                         .withRetryPolicy(DefaultRetryPolicy.INSTANCE);
                 builder.withPort(getConfiguration().getPort());
+
+                String username = getConfiguration().getUsername();
+                String password = getConfiguration().getPassword();
+                if(!isBlank(username) && !isBlank(password)) {
+                  builder.withCredentials(username, password);
+                }
 
                 if (getConfiguration().getTokenAwareLoadBalancingLocalDC().isPresent() &&
                         getConfiguration().getTokenAwareLoadBalancingUsedHostsPerRemoteDc() >= 0) {

--- a/modules/cassandra-datastax/src/main/java/com/intuit/wasabi/cassandra/datastax/DefaultCassandraDriver.java
+++ b/modules/cassandra-datastax/src/main/java/com/intuit/wasabi/cassandra/datastax/DefaultCassandraDriver.java
@@ -54,7 +54,6 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -93,12 +92,10 @@ public class DefaultCassandraDriver implements CassandraDriver {
                 builder.addContactPoints(nodes.toArray(new String[nodes.size()]))
                         .withRetryPolicy(DefaultRetryPolicy.INSTANCE);
                 builder.withPort(getConfiguration().getPort());
-
-                String username = getConfiguration().getUsername();
-                String password = getConfiguration().getPassword();
-                if(!isBlank(username) && !isBlank(password)) {
-                  builder.withCredentials(username, password);
-                }
+                builder.withCredentials(
+                        getConfiguration().getUsername(),
+                        getConfiguration().getPassword()
+                );
 
                 if (getConfiguration().getTokenAwareLoadBalancingLocalDC().isPresent() &&
                         getConfiguration().getTokenAwareLoadBalancingUsedHostsPerRemoteDc() >= 0) {

--- a/modules/database/src/main/resources/database.properties
+++ b/modules/database/src/main/resources/database.properties
@@ -17,8 +17,8 @@ database.url.host:${mysql.host}
 database.url.port:${mysql.port}
 database.url.dbname:${mysql.dbName}
 database.url.args:${mysql.Args}
-database.user:readwrite
-database.password:readwrite
-database.pool.partitions:1
-database.pool.connections.min:10
-database.pool.connections.max:30
+database.user:${mysql.username}
+database.password:${mysql.password}
+database.pool.partitions:${mysql.numPartitions}
+database.pool.connections.min:${mysql.minConnections}
+database.pool.connections.max:${mysql.maxConnections}

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/ClientConfiguration.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/ClientConfiguration.java
@@ -60,6 +60,16 @@ public class ClientConfiguration implements CassandraDriver.Configuration {
     }
 
     @Override
+    public String getUsername() {
+        return getProperty("username", properties, "");
+    }
+
+    @Override
+    public String getPassword() {
+        return getProperty("password", properties, "");
+    }
+
+    @Override
     public int getPort() {
         return parseInt(getProperty("port", properties, "9160"));
     }

--- a/modules/repository-datastax/src/main/resources/cassandra_client_config.properties
+++ b/modules/repository-datastax/src/main/resources/cassandra_client_config.properties
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###############################################################################
+username:${cassandra.username}
+password:${cassandra.password}
 nodeHosts:${cassandra.experiments.nodeHosts}
 port:${cassandra.experiments.port}
 useSSL:${cassandra.experiments.useSSL}
@@ -44,4 +46,3 @@ maxConnectionsPerHostRemote:1
 maxRequestPerConnectionLocal:1024
 maxRequestPerConnectionRemote:256
 poolTimeoutMillis:0
-

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,15 @@ http://www.w3.org/2001/XMLSchema-instance">
         <mysql.host>localhost</mysql.host>
         <mysql.port>3306</mysql.port>
         <mysql.dbName>wasabi</mysql.dbName>
+        <mysql.username>readwrite</mysql.username>
+        <mysql.password>readwrite</mysql.password>
+        <mysql.numPartitions>1</mysql.numPartitions>
+        <mysql.minConnections>10</mysql.minConnections>
+        <mysql.maxConnections>30</mysql.maxConnections>
         <mysql.Args>verifyServerCertificate=false&amp;useSSL=false&amp;requireSSL=false&amp;autoReconnect=true&amp;autoReconnectForPools=true</mysql.Args>
 
+        <cassandra.username></cassandra.username>
+        <cassandra.password></cassandra.password>
         <cassandra.experiments.keyspaceName>wasabi_experiments</cassandra.experiments.keyspaceName>
         <cassandra.experiments.nodeHosts>localhost</cassandra.experiments.nodeHosts>
         <cassandra.experiments.port>9042</cassandra.experiments.port>


### PR DESCRIPTION
Moves configuration of mysql and cassandra out to properties and environment variables to make it easier to work with remote storage hosts. This will make it easier to configure these hosts from one location.

#### Mysql Properties
* moves configuration to properties file

#### Cassandra Properties
* adds username and password accessors
* moves configuration into properties
* Adds optionality for CQLSH_VERSION

#### Starting Wasabi
* allow environment variables for mysql and cassandra hosts to be passed in for remote hosts


### Running Wasabi with remote storage

##### Set Mysql and Cassandra credentials
* modify /pom.xml

##### Download Cassandra migration tool https://oss.sonatype.org/content/repositories/public/com/builtamont/cassandra-migration/0.9/cassandra-migration-0.9-jar-with-dependencies.jar

##### Set up your environment variables
* Set location of the migration tool 
`export CASSANDRA_MIGRATION=/location/of/cassandra-migration-0.9-jar-with-dependencies.jar`
* Set location of migration scripts within your project 
`export MIGRATION_SCRIPT=/location/of/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration`

##### Set up Cassandra tables
`CQLSH_VERSION=<version> CQLSH_USERNAME=<username> CQLSH_PASSWORD=<pwd> CQLSH_HOST=<host> bin/docker/migration.sh`

##### Run Wasabi with env variables for remote storage hosts
`MYSQL_HOST=<mysql_host> NODE_HOST=<cassandra_host> ./bin/wasabi.sh start:wasabi`