### PR TITLE
Fix security hole in Feedback dialog

### DIFF
--- a/modules/ui/app/scripts/controllers/DialogModalCtrl.js
+++ b/modules/ui/app/scripts/controllers/DialogModalCtrl.js
@@ -7,8 +7,9 @@ angular.module('wasabi.controllers')
 
                 $scope.header = options.header;
 
-                // Use $sce (Strict Contextual Escaping) to safely insert HTML into the message.
-                $scope.description = $sce.trustAsHtml(options.description);
+                $scope.description = options.description;
+                $scope.descriptionWithHTML = $sce.trustAsHtml(options.descriptionWithHTML);
+                $scope.showWithHTML = (options.descriptionWithHTML && options.descriptionWithHTML.length > 0);
 
                 $scope.okLabel = 'OK';
                 if (options.okLabel) {

--- a/modules/ui/app/scripts/controllers/FeedbackModalCtrl.js
+++ b/modules/ui/app/scripts/controllers/FeedbackModalCtrl.js
@@ -34,7 +34,10 @@ angular.module('wasabi.controllers')
                     }
                     if (!$scope.userInteractedWithScore) {
                         $scope.feedback.score = '6';
-                        $scope.feedback.comments += '[[NOTE: Score defaulted to 6 due to bug]]';
+                        if (!$scope.feedback.comments) {
+                            $scope.feedback.comments = '';
+                        }
+                        $scope.feedback.comments += ' [[NOTE: Score defaulted to 6 due to bug]]';
                     }
                     FeedbackFactory.sendFeedback($scope.feedback).$promise.then(function(/*result*/) {
                         UtilitiesFactory.trackEvent('saveItemSuccess',

--- a/modules/ui/app/scripts/controllers/FeedbackModalCtrl.js
+++ b/modules/ui/app/scripts/controllers/FeedbackModalCtrl.js
@@ -33,20 +33,17 @@ angular.module('wasabi.controllers')
                         delete $scope.feedback.comments;
                     }
                     if (!$scope.userInteractedWithScore) {
-                        delete $scope.feedback.score;
+                        $scope.feedback.score = '6';
+                        $scope.feedback.comments += '[[NOTE: Score defaulted to 6 due to bug]]';
                     }
                     FeedbackFactory.sendFeedback($scope.feedback).$promise.then(function(/*result*/) {
                         UtilitiesFactory.trackEvent('saveItemSuccess',
                             {key: 'dialog_name', value: 'feedback'});
-                        //$modalInstance.close();
                     }, function(reason) {
                         console.log(reason);
-                        //$modalInstance.close();
                     });
                 };
 
                 $scope.cancel = function () {
-                    //$modalInstance.close();
-                    //$modalInstance.dismiss('cancel');
                 };
             }]);

--- a/modules/ui/app/scripts/services/DialogsFactory.js
+++ b/modules/ui/app/scripts/services/DialogsFactory.js
@@ -26,7 +26,7 @@ angular.module('wasabi.services').factory('DialogsFactory', ['$modal',
                 });
             },
 
-            confirmDialog: function(msg, title, resultFunction, cancelFunction, okLabel, cancelLabel) {
+            confirmDialog: function(msg, title, resultFunction, cancelFunction, okLabel, cancelLabel, msgWithHTML) {
                 var modalInstance = $modal.open({
                     templateUrl: 'views/DialogModal.html',
                     controller: 'DialogModalCtrl',
@@ -36,6 +36,7 @@ angular.module('wasabi.services').factory('DialogsFactory', ['$modal',
                         options: function() {
                             var theOptions = {
                                 description: msg,
+                                descriptionWithHTML: msgWithHTML,
                                 header: title,
                                 okCallback: resultFunction,
                                 showCancel: true

--- a/modules/ui/app/scripts/services/UtilitiesFactory.js
+++ b/modules/ui/app/scripts/services/UtilitiesFactory.js
@@ -1015,9 +1015,11 @@ angular.module('wasabi.services').factory('UtilitiesFactory', ['Session', '$stat
                         title = 'Permanently Terminate Experiment';
                         break;
                 }
-                var msg = 'Are you sure you want to ' + stateChange + ' the experiment ' + experiment.label + '?';
+                var msg = 'Are you sure you want to ' + stateChange + ' the experiment ' + experiment.label + '?',
+                    msgWithHTML = null;
                 if (state.toLowerCase() === 'terminated') {
-                    msg = 'Are you sure you want to <span style="font-weight: bold;">PERMANENTLY TERMINATE</span> the experiment ' + experiment.label + '?';
+                    msg = null;
+                    msgWithHTML = 'Are you sure you want to <span style="font-weight: bold;">PERMANENTLY TERMINATE</span> the experiment ' + experiment.label + '?';
                 }
                 DialogsFactory.confirmDialog(msg, title,
                         function() {
@@ -1045,7 +1047,7 @@ angular.module('wasabi.services').factory('UtilitiesFactory', ['Session', '$stat
                                 that.handleGlobalError(response, 'The state of your experiment could not be changed.');
                             });
                         },
-                        function() {/* Don't do the state change */});
+                        function() {/* Don't do the state change */}, null, null, msgWithHTML);
             },
 
             deleteExperiment: function (experiment, afterDeleteFunction) {

--- a/modules/ui/app/views/DialogModal.html
+++ b/modules/ui/app/views/DialogModal.html
@@ -2,7 +2,8 @@
     <h1>{{header}}</h1>
 
     <div class="dialogContent">
-        <div class="instructions" ng-bind-html="description"></div>
+        <div ng-show="{{!showWithHTML}}" class="instructions" ng-bind="description"></div>
+        <div ng-show="{{showWithHTML}}" class="instructions" ng-bind-html="descriptionWithHTML"></div>
         <div class="buttonBar">
             <button id="btnConfirmOk" class="blue" ng-click="ok()">{{okLabel}}</button>
             <button class="cancel" ng-show="showCancel" ng-click="cancel()">{{cancelLabel}}</button>


### PR DESCRIPTION
Fixing so we don’t interpret HTML if it is in the feedback as HTML. This was there in order to pass in some bold face for one of the dialogs, so had to change the way the dialog works so I can pass that in that one case, but otherwise, by default, the HTML is safe.  Also fixed so we don’t pass a 0 score to the feedback.