### PR TITLE
Feature/rapid experiment fix

### DIFF
--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/AssignmentsModule.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/AssignmentsModule.java
@@ -29,6 +29,7 @@ import com.intuit.wasabi.assignment.cache.impl.AssignmentsMetadataCacheRefreshTa
 import com.intuit.wasabi.assignment.cache.impl.NoopAssignmentsMetadataCacheImpl;
 import com.intuit.wasabi.assignmentobjects.AssignmentEnvelopePayload;
 import com.intuit.wasabi.exceptions.AssignmentException;
+import com.intuit.wasabi.experiment.ExperimentsModule;
 import com.intuit.wasabi.export.DatabaseExport;
 import com.intuit.wasabi.export.Envelope;
 import com.intuit.wasabi.export.WebExport;
@@ -80,6 +81,7 @@ public class AssignmentsModule extends AbstractModule {
 
         install(new ExportModule());
         install(new CassandraRepositoryModule());
+        install(new ExperimentsModule());
 
         Properties properties = create(PROPERTY_NAME, AssignmentsModule.class);
 

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
@@ -610,7 +610,7 @@ public class AssignmentsImpl implements Assignments {
             if (createAssignment) {
                 if (experiment.getState() == Experiment.State.PAUSED) {
                     return nullAssignment(userID, applicationName, experimentID, Assignment.Status.EXPERIMENT_PAUSED);
-                } else if (experiment.getIsRapidExperiment()) {
+                } else if (experiment.getIsRapidExperiment() != null && experiment.getIsRapidExperiment()) {
                     //Get the latest state from the DB for rapid experiments if they are not in stopped state.
                     Experiment rapidExperiment = experimentUtil.getExperiment(experiment.getID());
                     if (rapidExperiment == null || !rapidExperiment.getState().equals(experiment.getState())) {

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
@@ -613,8 +613,9 @@ public class AssignmentsImpl implements Assignments {
                 } else if (experiment.getIsRapidExperiment() != null && experiment.getIsRapidExperiment()) {
                     //Get the latest state from the DB for rapid experiments if they are not in stopped state.
                     Experiment rapidExperiment = experimentUtil.getExperiment(experiment.getID());
+                    Experiment.Label rapidExperimentLabel = null != rapidExperiment ? rapidExperiment.getLabel(): null;
                     if (rapidExperiment == null || !rapidExperiment.getState().equals(experiment.getState())) {
-                        return getAssignment(userID, applicationName, rapidExperiment.getLabel(),
+                        return getAssignment(userID, applicationName, rapidExperimentLabel,
                                 context, createAssignment, ignoreSamplingPercent, segmentationProfile,
                                 headers, rapidExperiment, bucketList, userAssignments, exclusives);
                     }

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
@@ -613,7 +613,7 @@ public class AssignmentsImpl implements Assignments {
                 } else if (experiment.getIsRapidExperiment() != null && experiment.getIsRapidExperiment()) {
                     //Get the latest state from the DB for rapid experiments if they are not in stopped state.
                     Experiment rapidExperiment = experimentUtil.getExperiment(experiment.getID());
-                    Experiment.Label rapidExperimentLabel = null != rapidExperiment ? rapidExperiment.getLabel(): null;
+                    Experiment.Label rapidExperimentLabel = (null != rapidExperiment ? rapidExperiment.getLabel(): null);
                     if (rapidExperiment == null || !rapidExperiment.getState().equals(experiment.getState())) {
                         return getAssignment(userID, applicationName, rapidExperimentLabel,
                                 context, createAssignment, ignoreSamplingPercent, segmentationProfile,

--- a/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
+++ b/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
@@ -31,6 +31,7 @@ import com.intuit.wasabi.assignmentobjects.SegmentationProfile;
 import com.intuit.wasabi.assignmentobjects.User;
 import com.intuit.wasabi.cassandra.datastax.CassandraDriver;
 import com.intuit.wasabi.eventlog.EventLog;
+import com.intuit.wasabi.experiment.Experiments;
 import com.intuit.wasabi.experiment.Mutex;
 import com.intuit.wasabi.experiment.Pages;
 import com.intuit.wasabi.experiment.Priorities;
@@ -106,6 +107,7 @@ public class AssignmentsImplTest {
     final static Context context = Context.valueOf("PROD");
     final static String TEST_INGESTION_EXECUTOR_NAME = "TEST";
     AssignmentsImpl cassandraAssignments = mock(AssignmentsImpl.class);
+    private Experiments experimentUtil = mock(Experiments.class);
     private ExperimentRepository cassandraRepository = mock(ExperimentRepository.class);
     private ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
     private AnalyticsRepository analyticsRepository = mock(AnalyticsRepository.class);
@@ -139,7 +141,7 @@ public class AssignmentsImplTest {
         this.assignmentsImpl = new AssignmentsImpl(executors,
                 experimentRepository, assignmentsRepository,
                 ruleCache, pages,
-                assignmentDecorator, threadPoolExecutor, eventLog, metadataCacheEnabled, metadataCache);
+                assignmentDecorator, threadPoolExecutor, eventLog, metadataCacheEnabled, metadataCache, experimentUtil);
     }
 
     @Test
@@ -221,10 +223,10 @@ public class AssignmentsImplTest {
 
     @Test
     public void testGetSingleAssignmentNullAssignmentExperimentInDraftState() throws IOException {
-        AssignmentsImpl assignmentsImpl = spy(new AssignmentsImpl(new HashMap<String, AssignmentIngestionExecutor>(),
+        AssignmentsImpl assignmentsImpl = spy(new AssignmentsImpl(new HashMap(),
                 experimentRepository, assignmentsRepository,
                 ruleCache, pages, assignmentDecorator, threadPoolExecutor,
-                eventLog, metadataCacheEnabled, metadataCache));
+                eventLog, metadataCacheEnabled, metadataCache, experimentUtil));
         //Input
         Application.Name appName = Application.Name.valueOf("Test");
         User.ID user = User.ID.valueOf("testUser");
@@ -392,9 +394,10 @@ public class AssignmentsImplTest {
 
     @Test
     public void testGetSingleAssignmentNullAssignmentExperimentNoProfileMatch() throws IOException {
-        AssignmentsImpl assignmentsImpl = spy(new AssignmentsImpl(new HashMap<String, AssignmentIngestionExecutor>(),
+        AssignmentsImpl assignmentsImpl = spy(new AssignmentsImpl(new HashMap(),
                 experimentRepository, assignmentsRepository,
-                ruleCache, pages, assignmentDecorator, threadPoolExecutor, eventLog, metadataCacheEnabled, metadataCache));
+                ruleCache, pages, assignmentDecorator, threadPoolExecutor,
+                eventLog, metadataCacheEnabled, metadataCache, experimentUtil));
 
         //Input
         Application.Name appName = Application.Name.valueOf("Test");
@@ -497,9 +500,9 @@ public class AssignmentsImplTest {
 
     @Test(expected = AssertionError.class)
     public void testGetSingleAssignmentProfileMatchAssertNewAssignment() throws IOException {
-        AssignmentsImpl assignmentsImpl = spy(new AssignmentsImpl(new HashMap<String, AssignmentIngestionExecutor>(),
+        AssignmentsImpl assignmentsImpl = spy(new AssignmentsImpl(new HashMap(),
                 experimentRepository, assignmentsRepository, ruleCache, pages, assignmentDecorator, threadPoolExecutor,
-                eventLog, metadataCacheEnabled, metadataCache));
+                eventLog, metadataCacheEnabled, metadataCache, experimentUtil));
 
         //Input
         Application.Name appName = Application.Name.valueOf("Test");
@@ -552,9 +555,10 @@ public class AssignmentsImplTest {
 
     @Test
     public void testGetSingleAssignmentSuccess() throws IOException {
-        AssignmentsImpl assignmentsImpl = spy(new AssignmentsImpl(new HashMap<String, AssignmentIngestionExecutor>(),
+        AssignmentsImpl assignmentsImpl = spy(new AssignmentsImpl(new HashMap(),
                 experimentRepository, assignmentsRepository,
-                ruleCache, pages, assignmentDecorator, threadPoolExecutor, eventLog, metadataCacheEnabled, metadataCache));
+                ruleCache, pages, assignmentDecorator, threadPoolExecutor, eventLog,
+                metadataCacheEnabled, metadataCache, experimentUtil));
 
         //Input
         Application.Name appName = Application.Name.valueOf("Test");

--- a/modules/email/src/main/java/com/intuit/wasabi/email/impl/EmailEventLogListener.java
+++ b/modules/email/src/main/java/com/intuit/wasabi/email/impl/EmailEventLogListener.java
@@ -23,16 +23,22 @@ import com.intuit.wasabi.eventlog.EventLogListener;
 import com.intuit.wasabi.eventlog.events.BucketEvent;
 import com.intuit.wasabi.eventlog.events.EventLogEvent;
 import com.intuit.wasabi.eventlog.events.ExperimentEvent;
+import com.intuit.wasabi.eventlog.impl.EventLogImpl;
+import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * This listener is looking out for events and processes new events to
  * a format that can be sent via mail using the {@link com.intuit.wasabi.email.EmailService}
  */
 public class EmailEventLogListener implements EventLogListener {
+
+    private static final Logger LOGGER = getLogger(EventLogImpl.class);
 
     protected final EventLog eventLog;
     private final EmailService emailService;
@@ -74,6 +80,8 @@ public class EmailEventLogListener implements EventLogListener {
         String subject = emailTextProcessor.getSubject(event);
         String msg = emailTextProcessor.getMessage(event);
         Set<String> addressees = emailTextProcessor.getAddressees(event);
+
+        LOGGER.info("Sending email with subject:{}, message:{}, addressees:{}", subject, msg, addressees);
 
         emailService.doSend(subject, msg, addressees.toArray(new String[addressees.size()]));
 

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/AssignmentCountEnvelope.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/AssignmentCountEnvelope.java
@@ -89,7 +89,7 @@ public class AssignmentCountEnvelope implements Runnable {
         // For rapid experiments; checks if a set userCap is attained.
         // If so, changes the state of the experiment to PAUSED.
         boolean wasExperimentStateUpdateToCassandraSuccessful = false;
-        if (experiment.getIsRapidExperiment()) {
+        if (experiment.getIsRapidExperiment() != null && experiment.getIsRapidExperiment()) {
             int userCap = experiment.getUserCap();
             AssignmentCounts assignmentCounts = assignmentsRepository.getBucketAssignmentCount(experiment);
             if (assignmentCounts.getTotalUsers().getBucketAssignments() >= userCap - 1) {

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepository.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepository.java
@@ -486,7 +486,7 @@ public class CassandraAssignmentsRepository implements AssignmentsRepository {
             AssignmentCountEnvelope assignmentCountEnvelope = new AssignmentCountEnvelope(
                     this, experimentRepository, dbRepository, pair.getLeft(),
                     pair.getRight(), countUp, eventLog, date, assignUserToExport, assignBucketCount);
-            if (pair.getLeft().getIsRapidExperiment()) {
+            if (pair.getLeft().getIsRapidExperiment() != null && pair.getLeft().getIsRapidExperiment()) {
                 assignmentCountEnvelope.run();
             } else {
                 assignmentsCountExecutor.execute(assignmentCountEnvelope);

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepository.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/CassandraAssignmentsRepository.java
@@ -483,7 +483,14 @@ public class CassandraAssignmentsRepository implements AssignmentsRepository {
     private void incrementCounts(List<Pair<Experiment, Assignment>> assignments, Date date) {
         boolean countUp = true;
         assignments.forEach(pair -> {
-            assignmentsCountExecutor.execute(new AssignmentCountEnvelope(this, experimentRepository, dbRepository, pair.getLeft(), pair.getRight(), countUp, eventLog, date, assignUserToExport, assignBucketCount));
+            AssignmentCountEnvelope assignmentCountEnvelope = new AssignmentCountEnvelope(
+                    this, experimentRepository, dbRepository, pair.getLeft(),
+                    pair.getRight(), countUp, eventLog, date, assignUserToExport, assignBucketCount);
+            if (pair.getLeft().getIsRapidExperiment()) {
+                assignmentCountEnvelope.run();
+            } else {
+                assignmentsCountExecutor.execute(assignmentCountEnvelope);
+            }
         });
         LOGGER.debug("Finished assignmentsCountExecutor");
     }

--- a/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/AssignmentCountEnvelopeTest.java
+++ b/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/AssignmentCountEnvelopeTest.java
@@ -53,7 +53,7 @@ public class AssignmentCountEnvelopeTest {
         env.run();
         // so since the two parts a separate code fragments the fail of the first
         // should not result in a fail of the other
-        verify(exp, times(1)).getIsRapidExperiment();
+        verify(exp, times(2)).getIsRapidExperiment();
     }
 
     @Test
@@ -65,7 +65,7 @@ public class AssignmentCountEnvelopeTest {
         env.run();
         // so since the two parts a separate code fragments the fail of the first
         // should not result in a fail of the other
-        verify(exp, times(1)).getIsRapidExperiment();
+        verify(exp, times(2)).getIsRapidExperiment();
     }
 
     /**
@@ -77,7 +77,7 @@ public class AssignmentCountEnvelopeTest {
 //        doReturn(42).when(exp).getUserCap();
         when(exp.getIsRapidExperiment()).thenReturn(true);
         when(exp.getUserCap()).thenReturn(42);
-        when(ar.getBucketAssignmentCount(exp).getTotalUsers().getBucketAssignments()).thenReturn(41l);
+        when(ar.getBucketAssignmentCount(exp).getTotalUsers().getBucketAssignments()).thenReturn(40l);
 
         AssignmentCountEnvelope env = new AssignmentCountEnvelope(ar, cass, mysql, exp, assignment, true, el, date, true, true);
         env.run();


### PR DESCRIPTION
This change fixes the over assignment of users in rapid experiments beyond the user cap - due to stale experiment state in experiment metadata cache.