### PR TITLE
Removes use dbName statement from mysql migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ CQLSH_VERSION=<version> CQLSH_USERNAME=<username> CQLSH_PASSWORD=<pwd> CQLSH_HOS
 MYSQL_HOST=<mysql_host> NODE_HOST=<cassandra_host> ./bin/wasabi.sh start:wasabi
 ```
 
-##### Run Wasabi outside of docker with WASABI_CONFIGURATION for remote MySQL database
+##### Run Wasabi outside of docker with WASABI_CONFIGURATION for remote storage hosts
 ```bash
 WASABI_CONFIGURATION="
   -Ddatabase.url.host=$MYSQL_HOST\

--- a/README.md
+++ b/README.md
@@ -151,6 +151,23 @@ CQLSH_VERSION=<version> CQLSH_USERNAME=<username> CQLSH_PASSWORD=<pwd> CQLSH_HOS
 MYSQL_HOST=<mysql_host> NODE_HOST=<cassandra_host> ./bin/wasabi.sh start:wasabi
 ```
 
+##### Run Wasabi outside of docker with WASABI_CONFIGURATION for remote MySQL database
+```bash
+WASABI_CONFIGURATION="
+  -Ddatabase.url.host=$MYSQL_HOST\
+  -Ddatabase.url.port=$MYSQL_PORT\
+  -Ddatabase.url.dbname=$MYSQL_DATABASE\
+  -Ddatabase.user=$MYSQL_USER\
+  -Ddatabase.password=$MYSQL_PASSWORD\
+  -Ddatabase.pool.connections.min=$MYSQL_MIN_CONNECTIONS\
+  -Ddatabase.pool.connections.max=$MYSQL_MAX_CONNECTIONS\
+  -Dusername=$CASSANDRA_USER\
+  -Dpassword=$CASSANDRA_PASSWORD\
+  -DnodeHosts=$CASSANDRA_HOST\
+  -DtokenAwareLoadBalancingLocalDC=$CASSANDRA_DATACENTER\
+  -Dapplication.http.port=$PORT" bash usr/local/wasabi-main-*/bin/run
+```
+
 #### Troubleshooting
 
 * While starting Wasabi, if you see an error when the docker containers are starting up, you could do the following:

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V001__Create_experiment_table.sql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V001__Create_experiment_table.sql
@@ -1,5 +1,3 @@
-USE `${mysql.dbName}`;
-
 CREATE TABLE `experiment` (
   `id` varbinary(16) NOT NULL,
   `version` integer NOT NULL DEFAULT 0,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V002__Create_bucket_table.sql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V002__Create_bucket_table.sql
@@ -1,5 +1,3 @@
-USE `${mysql.dbName}`;
-
 CREATE TABLE `bucket` (
   `experiment_id` varbinary(16) NOT NULL,
   `label` varchar(64) COLLATE utf8_bin NOT NULL,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V003__Create_event_impression_table.sql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V003__Create_event_impression_table.sql
@@ -1,5 +1,3 @@
-USE `${mysql.dbName}`;
-
 CREATE TABLE `event_impression` (
   `user_id` varchar(48) COLLATE utf8_bin NOT NULL,
   `experiment_id` varbinary(16) NOT NULL,
@@ -11,4 +9,3 @@ CREATE TABLE `event_impression` (
   KEY `timestamp` (`timestamp`),
   CONSTRAINT `event_impression_ibfk_1` FOREIGN KEY (`experiment_id`,`bucket_label`) REFERENCES `bucket` (`experiment_id`,`label`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
-

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V004__Create_event_action_table.sql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V004__Create_event_action_table.sql
@@ -1,5 +1,3 @@
-USE `${mysql.dbName}`;
-
 CREATE TABLE `event_action` (
   `user_id` varchar(48) COLLATE utf8_bin NOT NULL,
   `experiment_id` varbinary(16) NOT NULL,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V005__Create_experiment_rollup_table.sql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V005__Create_experiment_rollup_table.sql
@@ -1,5 +1,3 @@
-USE `${mysql.dbName}`;
-
 CREATE TABLE `experiment_rollup` (
   `experiment_id` varbinary(16) NOT NULL,
   `day` date NOT NULL,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V006__Create_on_delete_experiment_trigger.sql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V006__Create_on_delete_experiment_trigger.sql
@@ -1,5 +1,3 @@
-USE `${mysql.dbName}`;
-
 --
 -- Cascading deletes from experiment rows to the other tables.
 --

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V007__Create_on_update_experiment_trigger.sql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V007__Create_on_update_experiment_trigger.sql
@@ -1,5 +1,3 @@
-USE `${mysql.dbName}`;
-
 --
 -- Auto-versioning of deleted experiments.
 --

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V008__Alter_bucket_table.sql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V008__Alter_bucket_table.sql
@@ -1,4 +1,2 @@
-USE `${mysql.dbName}`;
-
 alter table `bucket`
 add `state` varchar(16) NOT NULL DEFAULT 'OPEN';

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V009__alter_event_impression_and_action_tables.sql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V009__alter_event_impression_and_action_tables.sql
@@ -1,4 +1,2 @@
-USE `${mysql.dbName}`;
-
 alter table event_impression add payload varchar(4096) COLLATE utf8_bin;
 alter table event_action add payload varchar(4096) COLLATE utf8_bin;

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V010__add_event_context.sql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V010__add_event_context.sql
@@ -1,4 +1,2 @@
-USE `${mysql.dbName}`;
-
 alter table event_impression add context varchar(200) DEFAULT "PROD" COLLATE utf8_bin;
 alter table event_action add context varchar(200) DEFAULT "PROD" COLLATE utf8_bin;

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V011__alter_rollups_table.sql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V011__alter_rollups_table.sql
@@ -1,5 +1,3 @@
-USE `${mysql.dbName}`;
-
 alter table experiment_rollup
 add context varchar(200) NOT NULL DEFAULT 'PROD',
 DROP INDEX entry,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V012__alter_context.sql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V012__alter_context.sql
@@ -1,5 +1,3 @@
-USE `${mysql.dbName}`;
-
 alter table event_impression modify context varchar(200) DEFAULT "PROD" COLLATE utf8_general_ci;
 alter table event_action modify context varchar(200) DEFAULT "PROD" COLLATE utf8_general_ci;
 alter table experiment_rollup modify context varchar(200) DEFAULT "PROD" COLLATE utf8_general_ci;

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V013__Create_user_experiment_properties.sql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V013__Create_user_experiment_properties.sql
@@ -1,5 +1,3 @@
-USE `${mysql.dbName}`;
-
 CREATE TABLE IF NOT EXISTS `user_experiment_properties` (
   `user_id` varchar(48) COLLATE utf8_bin NOT NULL,
   `experiment_id` varbinary(16) NOT NULL,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V014__alter_user_id.sql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V014__alter_user_id.sql
@@ -1,5 +1,3 @@
-USE `${mysql.dbName}`;
-
 ALTER TABLE user_experiment_properties MODIFY user_id varchar(200) COLLATE utf8_bin NOT NULL;
 ALTER TABLE event_impression MODIFY user_id varchar(200) COLLATE utf8_bin NOT NULL;
 ALTER TABLE event_action MODIFY user_id varchar(200) COLLATE utf8_bin NOT NULL;


### PR DESCRIPTION
This PR decouples the database name configuration from the migration scripts and allows us to rely solely on `database.properties` as the single source of configuration for mysql. This also gives us the flexibility to override the mysql configuration in WASABI_CONFIGURATION when we call the run script

#### Example
```
WASABI_CONFIGURATION="-Ddatabase.url.port=$PORT -Ddatabase.url.dbname=mydb" ./wasabi-main-*-SNAPSHOT-development/bin/run
```


#### Assumptions
* Any object calling these scripts has established a connection with the database, with a connection string that inherently includes the database name

