### PR TITLE
Feature/vagrant integration test on jenkins

### DIFF
--- a/modules/cassandra-datastax/src/main/java/com/intuit/wasabi/cassandra/datastax/CassandraDriver.java
+++ b/modules/cassandra-datastax/src/main/java/com/intuit/wasabi/cassandra/datastax/CassandraDriver.java
@@ -157,6 +157,18 @@ public interface CassandraDriver extends Closeable {
         int getPoolTimeoutMillis();
 
         /**
+         * Returns the defined connection timeout in milliseconds.
+         * @return the defined connection timeout in milliseconds
+         */
+        int getConnectTimeoutMillis();
+
+        /**
+         * Returned the per-host read timeout in milliseconds from the configuration.
+         * @return the defined read timeout in milliseconds from the configuration
+         */
+        int getReadTimeoutMillis();
+
+        /**
          * Returns max connections per remote host
          * @return max connections per remote host
          */

--- a/modules/cassandra-datastax/src/main/java/com/intuit/wasabi/cassandra/datastax/DefaultCassandraDriver.java
+++ b/modules/cassandra-datastax/src/main/java/com/intuit/wasabi/cassandra/datastax/DefaultCassandraDriver.java
@@ -27,6 +27,7 @@ import com.datastax.driver.core.ProtocolOptions;
 import com.datastax.driver.core.QueryLogger;
 import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.SocketOptions;
 import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
@@ -145,6 +146,17 @@ public class DefaultCassandraDriver implements CassandraDriver {
 
                 //Configure to use compression
                 builder.withCompression(ProtocolOptions.Compression.LZ4);
+
+
+                //The connection timeout in milliseconds.
+                //As the name implies, the connection timeout defines how long the driver waits to establish a new connection to a Cassandra node before giving up.
+                //Default value is 5000ms
+                builder.getConfiguration().getSocketOptions().setConnectTimeoutMillis(getConfiguration().getConnectTimeoutMillis());
+
+                //The per-host read timeout in milliseconds.
+                //This defines how long the driver will wait for a given Cassandra node to answer a query.
+                //Default value is 12000ms
+                builder.getConfiguration().getSocketOptions().setReadTimeoutMillis(getConfiguration().getReadTimeoutMillis());
 
                 // SSL connection
                 if (getConfiguration().useSSL()) {

--- a/modules/functional-test/Vagrantfile
+++ b/modules/functional-test/Vagrantfile
@@ -13,8 +13,8 @@ Vagrant.configure("2") do |config|
 
         dev.vm.provider "virtualbox" do |v|
             v.name = "wasabi.os.it.vbox"
-            v.memory = 4096
-            v.cpus = 4
+            v.memory = 8192
+            v.cpus = 8
             v.customize ["modifyvm", :id, "--cableconnected1", "on"]
         end
     end

--- a/modules/functional-test/provision.sh
+++ b/modules/functional-test/provision.sh
@@ -25,8 +25,9 @@ yum -y install httpd
 sudo service httpd start
 
 # install Oracle JDK
-wget --no-cookies --no-check-certificate --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/8u92-b14/jdk-8u92-linux-x64.rpm"
-sudo yum -y localinstall jdk-8u92-linux-x64.rpm
+wget --no-check-certificate -c --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.rpm
+
+sudo yum -y localinstall jdk-8u131-linux-x64.rpm
 
 cat <<EOF | sudo tee -a /etc/yum.repos.d/datastax.repo
 [datastax]

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/ClientConfiguration.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/ClientConfiguration.java
@@ -16,6 +16,7 @@
 package com.intuit.wasabi.repository.cassandra;
 
 import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.SocketOptions;
 import com.intuit.wasabi.cassandra.datastax.CassandraDriver;
 
 import java.util.Arrays;
@@ -133,6 +134,16 @@ public class ClientConfiguration implements CassandraDriver.Configuration {
     @Override
     public int getPoolTimeoutMillis() {
         return parseInt(getProperty("poolTimeoutMillis", properties, "0"));
+    }
+
+    @Override
+    public int getConnectTimeoutMillis() {
+        return parseInt(getProperty("connectTimeoutMillis", properties, String.valueOf(SocketOptions.DEFAULT_CONNECT_TIMEOUT_MILLIS)));
+    }
+
+    @Override
+    public int getReadTimeoutMillis() {
+        return parseInt(getProperty("readTimeoutMillis", properties, String.valueOf(SocketOptions.DEFAULT_READ_TIMEOUT_MILLIS)));
     }
 
     @Override

--- a/modules/repository-datastax/src/main/resources/cassandra_client_config.properties
+++ b/modules/repository-datastax/src/main/resources/cassandra_client_config.properties
@@ -28,12 +28,12 @@ slowQueryLoggingThresholdMilli:100
 #The connection timeout in milliseconds.
 #As the name implies, the connection timeout defines how long the driver waits to establish a new connection to a Cassandra node before giving up.
 #Default value is 5000ms, increasing to 1 minutes to make functional tests run even in very low resource containers/environments.
-connectTimeoutMillis:5000
+connectTimeoutMillis:60000
 
 #The per-host read timeout in milliseconds.
 #This defines how long the driver will wait for a given Cassandra node to answer a query.
-#Default value is 12000ms, increasing to 5 minutes to make functional tests run even in very low resource containers/environments.
-readTimeoutMillis:12000
+#Default value is 12000ms, increasing to 2 minutes to make functional tests run even in very low resource containers/environments.
+readTimeoutMillis:120000
 
 #Both token aware balancing option is required. Otherwise will default to round robin policy
 #if the LocalDC is specified but the UsedHostsPerRemoteDc < 0 then we will use round robin policy

--- a/modules/repository-datastax/src/main/resources/cassandra_client_config.properties
+++ b/modules/repository-datastax/src/main/resources/cassandra_client_config.properties
@@ -27,13 +27,13 @@ slowQueryLoggingThresholdMilli:100
 
 #The connection timeout in milliseconds.
 #As the name implies, the connection timeout defines how long the driver waits to establish a new connection to a Cassandra node before giving up.
-#Default value is 5000ms
+#Default value is 5000ms, increasing to 1 minutes to make functional tests run even in very low resource containers/environments.
 connectTimeoutMillis:60000
 
 #The per-host read timeout in milliseconds.
 #This defines how long the driver will wait for a given Cassandra node to answer a query.
-#Default value is 12000ms
-readTimeoutMillis:120000
+#Default value is 12000ms, increasing to 5 minutes to make functional tests run even in very low resource containers/environments.
+readTimeoutMillis:180000
 
 #Both token aware balancing option is required. Otherwise will default to round robin policy
 #if the LocalDC is specified but the UsedHostsPerRemoteDc < 0 then we will use round robin policy

--- a/modules/repository-datastax/src/main/resources/cassandra_client_config.properties
+++ b/modules/repository-datastax/src/main/resources/cassandra_client_config.properties
@@ -28,12 +28,12 @@ slowQueryLoggingThresholdMilli:100
 #The connection timeout in milliseconds.
 #As the name implies, the connection timeout defines how long the driver waits to establish a new connection to a Cassandra node before giving up.
 #Default value is 5000ms, increasing to 1 minutes to make functional tests run even in very low resource containers/environments.
-connectTimeoutMillis:60000
+connectTimeoutMillis:5000
 
 #The per-host read timeout in milliseconds.
 #This defines how long the driver will wait for a given Cassandra node to answer a query.
 #Default value is 12000ms, increasing to 5 minutes to make functional tests run even in very low resource containers/environments.
-readTimeoutMillis:180000
+readTimeoutMillis:12000
 
 #Both token aware balancing option is required. Otherwise will default to round robin policy
 #if the LocalDC is specified but the UsedHostsPerRemoteDc < 0 then we will use round robin policy

--- a/modules/repository-datastax/src/main/resources/cassandra_client_config.properties
+++ b/modules/repository-datastax/src/main/resources/cassandra_client_config.properties
@@ -25,6 +25,16 @@ keyspaceName:${cassandra.experiments.keyspaceName}
 isSlowQueryLoggingEnabled:False
 slowQueryLoggingThresholdMilli:100
 
+#The connection timeout in milliseconds.
+#As the name implies, the connection timeout defines how long the driver waits to establish a new connection to a Cassandra node before giving up.
+#Default value is 5000ms
+connectTimeoutMillis:60000
+
+#The per-host read timeout in milliseconds.
+#This defines how long the driver will wait for a given Cassandra node to answer a query.
+#Default value is 12000ms
+readTimeoutMillis:120000
+
 #Both token aware balancing option is required. Otherwise will default to round robin policy
 #if the LocalDC is specified but the UsedHostsPerRemoteDc < 0 then we will use round robin policy
 tokenAwareLoadBalancingLocalDC:${cassandra.local.dc}


### PR DESCRIPTION
Following changes are done to make sure functional test run successfully on Vagrant VM and on Jenkins:
 - Increase Cassandra connection & request timeout values
 - Increased resources (memory & cpu) for vagrant VM

Also, had to update JDK location...