### PR TITLE
adding handling for empty tag list and unit test

### DIFF
--- a/modules/functional-test/pom.xml
+++ b/modules/functional-test/pom.xml
@@ -210,6 +210,7 @@
                 <targetPath>${basedir}/target/classes</targetPath>
                 <includes>
                     <include>testng.xml</include>
+                    <include>testng_applicationtaglist.xml</include>
                     <include>testng_authTest.xml</include>
                     <include>testng_feedbackTest.xml</include>
                     <include>testng_forcedfailure.xml</include>

--- a/modules/functional-test/src/main/java/com/intuit/wasabi/tests/library/TestBase.java
+++ b/modules/functional-test/src/main/java/com/intuit/wasabi/tests/library/TestBase.java
@@ -3701,6 +3701,19 @@ public class TestBase extends ServiceTestBase {
     }
 
     /**
+     * Sends a GET request to retrieve all experiment tags for any application. The response must contain HTTP
+     * {@code HttpStatus.SC_OK}.
+     *
+     * @return an experiment
+     */
+    public String getExperimentTags() {
+        String uri = "applications/tags";
+        response = apiServerConnector.doGet(uri);
+        assertReturnCode(response, HttpStatus.SC_OK);
+        return response.jsonPath().prettify();
+    }
+
+    /**
      * Sends a POST request to receive statistics for an experiment. The response must contain {@link HttpStatus#SC_OK}.
      *
      * @param experiment the experiment

--- a/modules/functional-test/src/main/java/com/intuit/wasabi/tests/service/ApplicationTagListIntegrationTest.java
+++ b/modules/functional-test/src/main/java/com/intuit/wasabi/tests/service/ApplicationTagListIntegrationTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright 2017 Intuit
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.intuit.wasabi.tests.service;
+
+import com.intuit.wasabi.tests.library.TestBase;
+import com.intuit.wasabi.tests.library.util.serialstrategies.DefaultNameExclusionStrategy;
+import com.intuit.wasabi.tests.model.Experiment;
+import com.intuit.wasabi.tests.model.factory.ExperimentFactory;
+import org.apache.http.HttpStatus;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.UUID;
+
+import static com.intuit.wasabi.tests.library.util.Constants.EXPERIMENT_STATE_DELETED;
+
+/**
+ * Integration Test for the retrieval of ExperimentTags by Application.
+ */
+public class ApplicationTagListIntegrationTest extends TestBase {
+
+    private Experiment experiment;
+    private String appName = "tagListTest-" + UUID.randomUUID();
+
+    /**
+     * Set up one experiment that has no tags.
+     */
+    @BeforeClass
+    public void setUp() {
+        setResponseLogLengthLimit(1000);
+
+        experiment = ExperimentFactory.createExperiment();
+        experiment.startTime = "2015-08-01T00:00:00+0000";
+        experiment.endTime = "2015-08-08T00:00:00+0000";
+        experiment.samplingPercent = 0.5;
+        experiment.label = "experiment";
+        experiment.applicationName = appName;
+
+        DefaultNameExclusionStrategy experimentComparisonStrategy = new DefaultNameExclusionStrategy("creationTime", "modificationTime", "ruleJson");
+        experiment.setSerializationStrategy(experimentComparisonStrategy);
+
+    }
+
+
+    @Test(dependsOnGroups = {"ping"})
+    public void t_RetrieveTagList() {
+        //creates an experiment for that app
+        this.experiment = postExperiment(experiment);
+        //retrieve response (method checks for status code OK)
+        String response = getExperimentTags();
+    }
+
+    @AfterClass
+    public void terminateAndDelete() {
+        experiment.state = EXPERIMENT_STATE_DELETED;
+        putExperiment(experiment, HttpStatus.SC_NO_CONTENT);
+    }
+
+}

--- a/modules/functional-test/testng.xml
+++ b/modules/functional-test/testng.xml
@@ -37,6 +37,7 @@
         <suite-file path="testng_segHttpHeader.xml" />
         <suite-file path="testng_segRuleFix.xml" />
         <suite-file path="testng_repeatStateInconsistency.xml" />
+        <suite-file path="testng_applicationtaglist.xml" />
 
         <!-- final clean up -->
         <suite-file path="testng_teardown.xml" />

--- a/modules/functional-test/testng_applicationtaglist.xml
+++ b/modules/functional-test/testng_applicationtaglist.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2017 Intuit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+
+<suite name="ApplicationTagListIntegrationTest" parallel="false">
+    <test name="ApplicationTagListIntegrationTest">
+        <classes>
+            <class name="com.intuit.wasabi.tests.service.ApplicationTagListIntegrationTest"/>
+        </classes>
+    </test>
+</suite>

--- a/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/CassandraExperimentRepository.java
+++ b/modules/repository-datastax/src/main/java/com/intuit/wasabi/repository/cassandra/impl/CassandraExperimentRepository.java
@@ -1262,7 +1262,9 @@ public class CassandraExperimentRepository implements ExperimentRepository {
                 for (ExperimentTagsByApplication expTagsByApp : expTagApplication) {
                     allTagsForApplication.addAll(expTagsByApp.getTags());
                 }
-                result.put(Application.Name.valueOf(expTagApplication.get(0).getAppName()), allTagsForApplication);
+
+                if (!expTagApplication.isEmpty())
+                    result.put(Application.Name.valueOf(expTagApplication.get(0).getAppName()), allTagsForApplication);
             }
 
             return result;

--- a/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraExperimentRepositoryTest.java
+++ b/modules/repository-datastax/src/test/java/com/intuit/wasabi/repository/cassandra/impl/CassandraExperimentRepositoryTest.java
@@ -49,6 +49,7 @@ import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -720,6 +721,33 @@ public class CassandraExperimentRepositoryTest {
         assertEquals(2, callResult.size());
         assertArrayEquals(exp1.toArray(), callResult.get(app01).toArray());
         assertArrayEquals(exp2.toArray(), callResult.get(app02).toArray());
+    }
+
+
+    @Test
+    public void testGetEmptyTagList() throws ExecutionException, InterruptedException {
+        //------ Input --------
+        Application.Name app01 = Application.Name.valueOf("app01");
+        List<Application.Name> appNames = Arrays.asList(app01);
+
+        List<ExperimentTagsByApplication> exp1Tags = Collections.emptyList();
+
+        //------ Mocking interacting calls
+        ListenableFuture<Result<ExperimentTagsByApplication>> dbResultFuture1 = mock(ListenableFuture.class);
+
+        Result<ExperimentTagsByApplication> dbResult1 = mock(Result.class);
+
+        when(mockExperimentTagAccessor.getExperimentTagsAsync("app01")).thenReturn(dbResultFuture1);
+
+        when(dbResultFuture1.get()).thenReturn(dbResult1);
+
+        when(dbResult1.all()).thenReturn(exp1Tags);
+
+        //------ Make call
+        Map<Name, Set<String>> callResult = repository.getTagListForApplications(appNames);
+
+        //------ Verify result
+        assertEquals(0, callResult.size()); // no results are returned without error
     }
 
 }


### PR DESCRIPTION
These changes fix the NP exception that is shown on the UI side when all Experiments are retrieved, but some applications have no associated tags stored with them.