### PR TITLE
Feature/state remodel

### DIFF
--- a/modules/api/src/main/java/com/intuit/wasabi/api/AssignmentsResource.java
+++ b/modules/api/src/main/java/com/intuit/wasabi/api/AssignmentsResource.java
@@ -59,7 +59,6 @@ import java.util.Map;
 import static com.google.common.collect.Maps.newHashMap;
 import static com.intuit.wasabi.api.APISwaggerResource.DEFAULT_LABELLIST;
 import static com.intuit.wasabi.api.APISwaggerResource.EXAMPLE_AUTHORIZATION_HEADER;
-import static com.intuit.wasabi.assignmentobjects.Assignment.Status.EXPERIMENT_EXPIRED;
 import static java.lang.Boolean.FALSE;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
@@ -734,7 +733,7 @@ public class AssignmentsResource {
         }
 
         // Only include `assignment` property if there is a definitive assignment, either to a bucket or not
-        if (assignment.getStatus() != EXPERIMENT_EXPIRED) {
+        if (assignment.getStatus().isDefinitiveAssignment()) {
             response.put("assignment",
                     nonNull(assignment.getBucketLabel()) ? assignment.getBucketLabel().toString() : null);
 

--- a/modules/assignment-objects/src/main/java/com/intuit/wasabi/assignmentobjects/Assignment.java
+++ b/modules/assignment-objects/src/main/java/com/intuit/wasabi/assignmentobjects/Assignment.java
@@ -284,7 +284,6 @@ public class Assignment {
         EXPERIMENT_IN_DRAFT_STATE(false),
         EXPERIMENT_PAUSED(false),
         NO_PROFILE_MATCH(false),
-        EXPERIMENT_EXPIRED(false),
         ASSIGNMENT_FAILED(false),
 
         EXISTING_ASSIGNMENT(true),

--- a/modules/assignment-objects/src/main/java/com/intuit/wasabi/assignmentobjects/Assignment.java
+++ b/modules/assignment-objects/src/main/java/com/intuit/wasabi/assignmentobjects/Assignment.java
@@ -285,7 +285,8 @@ public class Assignment {
         EXPERIMENT_PAUSED(false),
         NO_PROFILE_MATCH(false),
         // EXPERIMENT_EXPIRED is no longer used since the experiment is moved to PAUSED upon expiring.
-        // The status is kept for the historical data.
+        // The status is kept for the historical data in the downstream systems, but is not needed
+        // by Wasabi's application storage (Cassandra & Mysql)
         EXPERIMENT_EXPIRED(false),
         ASSIGNMENT_FAILED(false),
 

--- a/modules/assignment-objects/src/main/java/com/intuit/wasabi/assignmentobjects/Assignment.java
+++ b/modules/assignment-objects/src/main/java/com/intuit/wasabi/assignmentobjects/Assignment.java
@@ -284,6 +284,9 @@ public class Assignment {
         EXPERIMENT_IN_DRAFT_STATE(false),
         EXPERIMENT_PAUSED(false),
         NO_PROFILE_MATCH(false),
+        // EXPERIMENT_EXPIRED is no longer used since the experiment is moved to PAUSED upon expiring.
+        // The status is kept for the historical data.
+        EXPERIMENT_EXPIRED(false),
         ASSIGNMENT_FAILED(false),
 
         EXISTING_ASSIGNMENT(true),

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
@@ -515,10 +515,8 @@ public class AssignmentsImpl implements Assignments {
                     }
 
                     // Add the assignment to the global list of userAssignments of the user
-                    if (Experiment.State.PAUSED != experiment.getState()) { // the Experiment is set to PAUSED in the case of a reached endDate
-                        userAssignments.put(experiment.getID(), experiment.getLabel(),
-                                assignment.getBucketLabel() != null ? assignment.getBucketLabel().toString() : "null");
-                    }
+                    userAssignments.put(experiment.getID(), experiment.getLabel(),
+                            assignment.getBucketLabel() != null ? assignment.getBucketLabel().toString() : "null");
 
                     assignmentPairs.add(new ImmutablePair<>(experimentMap.get(experiment.getID()), assignment));
 

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
@@ -589,7 +589,9 @@ public class AssignmentsImpl implements Assignments {
         }
 
         if (currentTime > experiment.getEndTime().getTime()) {
+            // the experiment moves to the PAUSED state if the endtime is reached
             experiment.setState(Experiment.State.PAUSED);
+            repository.updateExperiment(experiment);
             return nullAssignment(userID, applicationName, experimentID,
                     Assignment.Status.EXPERIMENT_PAUSED);
         }

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
@@ -477,9 +477,9 @@ public class AssignmentsImpl implements Assignments {
         //Prepopulate bucket assignment counts for rapid experiments in running state in asynchronous mode
         List<Experiment.ID> experimentIds =
                 appPriorities.getPrioritizedExperiments()
-                .stream()
-                .filter(experiment -> (null != experiment.getIsRapidExperiment() && experiment.getIsRapidExperiment())
-                        && experiment.getState().equals(Experiment.State.RUNNING))
+                        .stream()
+                        .filter(experiment -> (null != experiment.getIsRapidExperiment() && experiment.getIsRapidExperiment())
+                                && experiment.getState().equals(Experiment.State.RUNNING))
                         .map(experiment -> experiment.getID())
                         .collect(Collectors.toList());
 
@@ -621,7 +621,8 @@ public class AssignmentsImpl implements Assignments {
         if (currentTime > experiment.getEndTime().getTime()) {
             // the experiment moves to the PAUSED state if the endtime is reached
             experiment.setState(Experiment.State.PAUSED);
-            repository.updateExperiment(experiment);
+            experimentUtil.updateExperimentState(experiment, Experiment.State.PAUSED);
+            metadataCache.refresh();
             return nullAssignment(userID, applicationName, experimentID,
                     Assignment.Status.EXPERIMENT_PAUSED);
         }
@@ -693,7 +694,7 @@ public class AssignmentsImpl implements Assignments {
             int userCap = experiment.getUserCap();
             AssignmentCounts assignmentCounts = null;
             if (null != prefetchedAssignmentCounts) {
-                 assignmentCounts = prefetchedAssignmentCounts.get(experiment.getID());
+                assignmentCounts = prefetchedAssignmentCounts.get(experiment.getID());
             }
             if (null == assignmentCounts) {
                 assignmentCounts = assignmentsRepository.getBucketAssignmentCount(experiment);

--- a/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
+++ b/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
@@ -323,6 +323,7 @@ public class AssignmentsImplTest {
         when(experiment.getID()).thenReturn(id);
         when(experiment.getEndTime().getTime()).thenReturn(1000000L);
         when(experiment.getLabel()).thenReturn(label);
+        when(experiment.getState()).thenReturn(Experiment.State.RUNNING);
 
         List<Experiment> expList = newArrayList(experiment);
 
@@ -347,7 +348,7 @@ public class AssignmentsImplTest {
 
         //Verify result
         assertThat(result.getStatus(), is(Assignment.Status.EXPERIMENT_PAUSED));
-        verify(experiment).setState(Experiment.State.PAUSED);
+        verify(experimentUtil).updateExperimentState(experiment, Experiment.State.PAUSED);
     }
 
     @Test
@@ -1732,7 +1733,6 @@ public class AssignmentsImplTest {
         //Verify expected result
         assertNull(returnedExperiment);
     }
-
 
 
     // FIXME:

--- a/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
+++ b/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
@@ -319,11 +319,9 @@ public class AssignmentsImplTest {
         HttpHeaders headers = mock(HttpHeaders.class);
 
         //Mock dependent interactions
-        Experiment experiment = mock(Experiment.class, RETURNS_DEEP_STUBS);
-        when(experiment.getID()).thenReturn(id);
-        when(experiment.getEndTime().getTime()).thenReturn(1000000L);
-        when(experiment.getLabel()).thenReturn(label);
-        when(experiment.getState()).thenReturn(Experiment.State.RUNNING);
+        Experiment experiment = Experiment.withID(id).withLabel(label)
+                .withState(Experiment.State.RUNNING).withStartTime(new Date(10000L))
+                .withEndTime(new Date(1000000L)).build();
 
         List<Experiment> expList = newArrayList(experiment);
 
@@ -342,6 +340,7 @@ public class AssignmentsImplTest {
         when(metadataCache.getPrioritizedExperimentListMap(appName)).thenReturn(prioritizedExperimentListOptional);
         when(metadataCache.getBucketList(id)).thenReturn(bucketList);
         when(metadataCache.getExclusionList(id)).thenReturn(exclusionList);
+        when(experimentUtil.getExperiment(id)).thenReturn(experiment);
 
         //This is actual call
         Assignment result = assignmentsImpl.doSingleAssignment(user, appName, label, context, true, true, segmentationProfile, headers);

--- a/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
+++ b/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
@@ -66,10 +66,8 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -77,11 +75,9 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadPoolExecutor;
 
-import static com.google.common.base.Predicates.in;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
-import static org.assertj.core.api.BDDAssertions.then;
 import static org.hamcrest.core.AnyOf.anyOf;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
@@ -344,7 +340,8 @@ public class AssignmentsImplTest {
         Assignment result = assignmentsImpl.doSingleAssignment(user, appName, label, context, true, true, segmentationProfile, headers);
 
         //Verify result
-        assertThat(result.getStatus(), is(Assignment.Status.EXPERIMENT_EXPIRED));
+        assertThat(result.getStatus(), is(Assignment.Status.EXPERIMENT_PAUSED));
+        verify(experiment).setState(Experiment.State.PAUSED);
     }
 
     @Test


### PR DESCRIPTION
If an experiment reaches the enddate it is currently not possible to further extend the duration. The experiment did move to a semi-stopped state where the `Assignment.Status` returned that the experiment expired. 

This branch changes the behavior for an expiring experiment in the sense that it is moved to PAUSED where otherwise the `Assignment.Status.EXPERIMENT_EXPIRED` was returned. The following Assignments get the `EXPERIMENT_PAUSED` state returned. The old Assignment.Status is kept for the historical records.