### PR TITLE
Fix so we can create superadmins.  Problem was wrong field being used…

### DIFF
--- a/modules/ui/app/scripts/controllers/AddSuperadminModalCtrl.js
+++ b/modules/ui/app/scripts/controllers/AddSuperadminModalCtrl.js
@@ -46,7 +46,7 @@ angular.module('wasabi.controllers')
                         $scope.validating = false;
                         if (results) {
                             $scope.superadmin = {};
-                            $scope.superadmin.userID = (results.userId ? results.userId : '');
+                            $scope.superadmin.userID = (results.username ? results.username : '');
                             $scope.superadmin.firstName = (results.firstName ? results.firstName : '');
                             $scope.superadmin.lastName = (results.lastName ? results.lastName : '');
                             $scope.superadmin.userEmail = (results.email ? results.email : '');


### PR DESCRIPTION
… from return from verify API.  On non-Intuit, that field had the username, too.  On Intuit, only the username field has the user name.