### PR TITLE
Made put assignment implementation in sync with the get/post single/batch assignments

### DIFF
--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
@@ -874,7 +874,7 @@ public class AssignmentsImpl implements Assignments {
                 for (PrioritizedExperiment prioritizedExperiment : prioritizedExperimentListOptional.get().getPrioritizedExperiments()) {
                     if (experimentLabel.equals(prioritizedExperiment.getLabel())) {
                         //Upon match, get the complete experiment object from cache
-                        result = metadataCache.getExperimentById(prioritizedExperiment.getID()).orElseGet(null);
+                        result = metadataCache.getExperimentById(prioritizedExperiment.getID()).orElse(null);
                         break;
                     }
                 }

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
@@ -866,7 +866,8 @@ public class AssignmentsImpl implements Assignments {
         Experiment result = null;
 
         if (metadataCacheEnabled) {
-            //First fetch experiment list sorted by priorities (only contains non-deleted experiment-ids)
+            //First fetch experiment list sorted by priorities (contains non-deleted experiment-ids).
+            //This experiment-priority list is the source of truth for ALL assignment flows while looking up experiment...
             Optional<PrioritizedExperimentList> prioritizedExperimentListOptional = metadataCache.getPrioritizedExperimentListMap(applicationName);
             if (prioritizedExperimentListOptional.isPresent()) {
                 //Iterate as per experiment priority and look for the matching experiment by their label

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
@@ -866,7 +866,7 @@ public class AssignmentsImpl implements Assignments {
         Experiment result = null;
 
         if (metadataCacheEnabled) {
-            //First fetch experiment list sorted by priorities
+            //First fetch experiment list sorted by priorities (only contains non-deleted experiment-ids)
             Optional<PrioritizedExperimentList> prioritizedExperimentListOptional = metadataCache.getPrioritizedExperimentListMap(applicationName);
             if (prioritizedExperimentListOptional.isPresent()) {
                 //Iterate as per experiment priority and look for the matching experiment by their label
@@ -874,6 +874,7 @@ public class AssignmentsImpl implements Assignments {
                     if (experimentLabel.equals(prioritizedExperiment.getLabel())) {
                         //Upon match, get the complete experiment object from cache
                         result = metadataCache.getExperimentById(prioritizedExperiment.getID()).orElseGet(null);
+                        break;
                     }
                 }
             }

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
@@ -866,11 +866,12 @@ public class AssignmentsImpl implements Assignments {
         Experiment result = null;
 
         if (metadataCacheEnabled) {
-            List<Experiment> experiments = metadataCache.getExperimentsByAppName(applicationName);
-            for (Experiment exp : experiments) {
-                if (experimentLabel.equals(exp.getLabel())) {
-                    result = exp;
-                    break;
+            Optional<PrioritizedExperimentList> prioritizedExperimentListOptional = metadataCache.getPrioritizedExperimentListMap(applicationName);
+            if (prioritizedExperimentListOptional.isPresent()) {
+                for (PrioritizedExperiment prioritizedExperiment : prioritizedExperimentListOptional.get().getPrioritizedExperiments()) {
+                    if (experimentLabel.equals(prioritizedExperiment.getLabel())) {
+                        result = metadataCache.getExperimentById(prioritizedExperiment.getID()).orElseGet(null);
+                    }
                 }
             }
         } else {

--- a/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
+++ b/modules/assignment/src/main/java/com/intuit/wasabi/assignment/impl/AssignmentsImpl.java
@@ -866,10 +866,13 @@ public class AssignmentsImpl implements Assignments {
         Experiment result = null;
 
         if (metadataCacheEnabled) {
+            //First fetch experiment list sorted by priorities
             Optional<PrioritizedExperimentList> prioritizedExperimentListOptional = metadataCache.getPrioritizedExperimentListMap(applicationName);
             if (prioritizedExperimentListOptional.isPresent()) {
+                //Iterate as per experiment priority and look for the matching experiment by their label
                 for (PrioritizedExperiment prioritizedExperiment : prioritizedExperimentListOptional.get().getPrioritizedExperiments()) {
                     if (experimentLabel.equals(prioritizedExperiment.getLabel())) {
+                        //Upon match, get the complete experiment object from cache
                         result = metadataCache.getExperimentById(prioritizedExperiment.getID()).orElseGet(null);
                     }
                 }

--- a/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
+++ b/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
@@ -1675,12 +1675,12 @@ public class AssignmentsImplTest {
 
         //Create input objects
         Application.Name appName = Application.Name.valueOf("Test");
-        Experiment.ID deleteExperimentId = Experiment.ID.newInstance(); //Experiment.ID.valueOf("");
+        Experiment.ID deletedExperimentId = Experiment.ID.newInstance(); //Experiment.ID.valueOf("");
         Experiment.ID runningExperimentId = Experiment.ID.newInstance(); //Experiment.ID.valueOf("");
         Experiment.Label commonExperimentLabel = Experiment.Label.valueOf("SameNamePresetTwice");
 
         Experiment deleteExperiment = mock(Experiment.class, RETURNS_DEEP_STUBS);
-        when(deleteExperiment.getID()).thenReturn(deleteExperimentId);
+        when(deleteExperiment.getID()).thenReturn(deletedExperimentId);
         when(deleteExperiment.getEndTime().getTime()).thenReturn(new Date().getTime() + 1000000L);
         when(deleteExperiment.getLabel()).thenReturn(commonExperimentLabel);
         when(deleteExperiment.getState()).thenReturn(Experiment.State.DELETED);
@@ -1700,7 +1700,7 @@ public class AssignmentsImplTest {
         //Mock interactions with the cache
         when(metadataCache.getPrioritizedExperimentListMap(appName)).thenReturn(prioritizedExperimentListOptional);
         when(metadataCache.getExperimentById(runningExperimentId)).thenReturn(Optional.of(runningExperiment));
-        when(metadataCache.getExperimentById(deleteExperimentId)).thenReturn(Optional.of(deleteExperiment));
+        when(metadataCache.getExperimentById(deletedExperimentId)).thenReturn(Optional.of(deleteExperiment));
 
         //Make actual call
         Experiment returnedExperiment = assignmentsImpl.getExperiment(appName, commonExperimentLabel);

--- a/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
+++ b/modules/assignment/src/test/java/com/intuit/wasabi/assignment/impl/AssignmentsImplTest.java
@@ -1679,12 +1679,12 @@ public class AssignmentsImplTest {
         Experiment.ID runningExperimentId = Experiment.ID.newInstance(); //Experiment.ID.valueOf("");
         Experiment.Label commonExperimentLabel = Experiment.Label.valueOf("SameNamePresetTwice");
 
-        Experiment deleteExperiment = mock(Experiment.class, RETURNS_DEEP_STUBS);
-        when(deleteExperiment.getID()).thenReturn(deletedExperimentId);
-        when(deleteExperiment.getEndTime().getTime()).thenReturn(new Date().getTime() + 1000000L);
-        when(deleteExperiment.getLabel()).thenReturn(commonExperimentLabel);
-        when(deleteExperiment.getState()).thenReturn(Experiment.State.DELETED);
-        when(deleteExperiment.getIsRapidExperiment()).thenReturn(false);
+        Experiment deletedExperiment = mock(Experiment.class, RETURNS_DEEP_STUBS);
+        when(deletedExperiment.getID()).thenReturn(deletedExperimentId);
+        when(deletedExperiment.getEndTime().getTime()).thenReturn(new Date().getTime() + 1000000L);
+        when(deletedExperiment.getLabel()).thenReturn(commonExperimentLabel);
+        when(deletedExperiment.getState()).thenReturn(Experiment.State.DELETED);
+        when(deletedExperiment.getIsRapidExperiment()).thenReturn(false);
 
         Experiment runningExperiment = mock(Experiment.class, RETURNS_DEEP_STUBS);
         when(runningExperiment.getID()).thenReturn(runningExperimentId);
@@ -1700,7 +1700,7 @@ public class AssignmentsImplTest {
         //Mock interactions with the cache
         when(metadataCache.getPrioritizedExperimentListMap(appName)).thenReturn(prioritizedExperimentListOptional);
         when(metadataCache.getExperimentById(runningExperimentId)).thenReturn(Optional.of(runningExperiment));
-        when(metadataCache.getExperimentById(deletedExperimentId)).thenReturn(Optional.of(deleteExperiment));
+        when(metadataCache.getExperimentById(deletedExperimentId)).thenReturn(Optional.of(deletedExperiment));
 
         //Make actual call
         Experiment returnedExperiment = assignmentsImpl.getExperiment(appName, commonExperimentLabel);

--- a/modules/functional-test/Vagrantfile
+++ b/modules/functional-test/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure("2") do |config|
 
-    config.vm.box = 'bento/centos-7.2'
+    config.vm.box = 'bento/centos-7.3'
     config.vm.provision "shell",  :path => "provision.sh"
     config.vm.provision "shell",  :path => "target/scripts/migration.sh"
     config.vm.provision "shell",  :path => "target/scripts/server-start.sh"

--- a/modules/functional-test/src/main/java/com/intuit/wasabi/tests/data/AssignmentDataProvider.java
+++ b/modules/functional-test/src/main/java/com/intuit/wasabi/tests/data/AssignmentDataProvider.java
@@ -92,7 +92,7 @@ public class AssignmentDataProvider extends CombinableDataProvider {
                 new Object[]{"DRAFT", HttpStatus.SC_BAD_REQUEST},
                 new Object[]{"PAUSED", HttpStatus.SC_OK},
                 new Object[]{"RUNNING", HttpStatus.SC_OK},
-                new Object[]{"TERMINATED", HttpStatus.SC_BAD_REQUEST}
+                new Object[]{"TERMINATED", HttpStatus.SC_NOT_FOUND}
         };
     }
 


### PR DESCRIPTION
Retrieve experiment based upon app-name & experiment-label by going through the application-experiments list as per their priorities (Similar to the get/post single/batch assignment flow)...

As application-experiments priority list only contains non-deleted experiment-ids, PUT flow is not going to find any deleted experiment for the assignment.