### PR TITLE
fixes wasabi packaging with surefire plugin update

### DIFF
--- a/modules/ui/Gruntfile.js
+++ b/modules/ui/Gruntfile.js
@@ -102,9 +102,13 @@ module.exports = function (grunt) {
                     ],
                     protocol: 'https',
                     port: 443,
-                    key: grunt.file.read('server.key').toString(),
-                    cert: grunt.file.read('server.crt').toString(),
-                    ca: grunt.file.read('ca.crt').toString()
+                    // FIXME: fails to read key files
+                    // key: grunt.file.read('server.key').toString(),
+                    // cert: grunt.file.read('server.crt').toString(),
+                    // ca: grunt.file.read('ca.crt').toString()
+                    key: '',
+                    cert: '',
+                    ca: ''
                 }
             }
         },

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ http://www.w3.org/2001/XMLSchema-instance">
     <description>Opinionated micro-service kernel.</description>
 
     <properties>
-    
+
         <!-- for integration test BEGIN -->
         <wasabi.cassandra.migration.resource.path>com/intuit/wasabi/repository/impl/cassandra/migration</wasabi.cassandra.migration.resource.path>
         <cassandra.migration.version>0.11</cassandra.migration.version>
@@ -42,7 +42,7 @@ http://www.w3.org/2001/XMLSchema-instance">
         <application.user.email>admin@example.com</application.user.email>
         <application.user.lastname>Admin</application.user.lastname>
         <!-- for integration test END -->
-            
+
         <default.time.zone>UTC</default.time.zone>
         <default.time.format>yyyy-MM-dd HH:mm:ss</default.time.format>
         <access.control.max.age.delta.seconds>86400</access.control.max.age.delta.seconds>
@@ -140,12 +140,12 @@ http://www.w3.org/2001/XMLSchema-instance">
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.11</version>
+                        <version>2.17</version>
                         <dependencies>
                             <dependency>
                                 <groupId>org.apache.maven.surefire</groupId>
                                 <artifactId>surefire-junit47</artifactId>
-                                <version>2.12</version>
+                                <version>2.17</version>
                             </dependency>
                         </dependencies>
                         <configuration>
@@ -173,12 +173,12 @@ http://www.w3.org/2001/XMLSchema-instance">
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.11</version>
+                        <version>2.17</version>
                         <dependencies>
                             <dependency>
                                 <groupId>org.apache.maven.surefire</groupId>
                                 <artifactId>surefire-junit47</artifactId>
-                                <version>2.12</version>
+                                <version>2.17</version>
                             </dependency>
                         </dependencies>
                         <configuration>


### PR DESCRIPTION
This pull request fixes currently dysfunctional wasabi .deb and .rpm packaging scripting.
The version of maven surefire plugin was outdated and required an update from version 2.11 to 2.17 for the packaging process to complete successfully.
The packaging script was also failing due to an error in the `modules/ui/Gruntfile.js` file, which was unable to read in the ssl certificate material from the local files (containing empty strings), a problem this pull request mitigates.