### PR TITLE
Fix build issues on Mac

### DIFF
--- a/modules/api/src/test/java/com/intuit/wasabi/api/error/WasabiExceptionProviderTest.java
+++ b/modules/api/src/test/java/com/intuit/wasabi/api/error/WasabiExceptionProviderTest.java
@@ -25,6 +25,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import javax.ws.rs.core.Response;
@@ -37,6 +39,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({ "jdk.internal.reflect.*" })
 @PrepareForTest({ErrorCode.class})
 public class WasabiExceptionProviderTest {
 

--- a/modules/event/src/test/java/com/intuit/wasabi/events/impl/EventsEnvelopeTest.java
+++ b/modules/event/src/test/java/com/intuit/wasabi/events/impl/EventsEnvelopeTest.java
@@ -31,6 +31,7 @@ import org.mockito.BDDMockito;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,6 +47,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.slf4j.LoggerFactory.getLogger;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({ "jdk.internal.reflect.*" })
 @PrepareForTest(LoggerFactory.class)
 public class EventsEnvelopeTest {
 

--- a/modules/repository-datastax/pom.xml
+++ b/modules/repository-datastax/pom.xml
@@ -172,7 +172,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.10</version>
+            <version>1.16.18</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -372,6 +372,12 @@ http://www.w3.org/2001/XMLSchema-instance">
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4-rule</artifactId>
+            <version>1.6.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>eu.codearte.catch-exception</groupId>
             <artifactId>catch-exception</artifactId>
             <version>1.4.4</version>


### PR DESCRIPTION
This is to fix build issues on the Mac regarding Issue #293. I'm not sure if this fixes the referenced issues, however, it does allow this to build and run on a Mac. The issue was with the lombok dependency generating the `wasabi-repository-datastax: Fatal error compiling: java.lang.NoClassDefFoundError: com/sun/tools/javac/file/BaseFileObject: com.sun.tools.javac.file.BaseFileObject` which was fixed in the lombok version 1.16.18. See issue [1315](https://github.com/rzwitserloot/lombok/issues/1315) in the lombok repository. Once this was added I had to also add some ignores to jdk.internal.reflect so PowerMock wouldn't try to stub these classes. Let me know if you have questions. Thanks! 