### PR TITLE
make cassandra migrations ignore column families that already exist 

### DIFF
--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V001__Create_Experiment_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V001__Create_Experiment_table.cql
@@ -1,6 +1,6 @@
 -- Query: Get experiment metadata
 
-create table experiment (
+create table if not exists experiment (
     id uuid,
 
     description varchar,
@@ -23,4 +23,4 @@ create table experiment (
 );
 
 -- Query: Get all experiment IDs for an app
-create index on experiment(app_name);
+create index if not exists on experiment(app_name);

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V002__Create_Bucket_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V002__Create_Bucket_table.cql
@@ -1,6 +1,6 @@
 -- Query: Get bucket metadata
 
-create table bucket (
+create table if not exists bucket (
     experiment_id uuid,
     label varchar,
     state text,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V003__Create_Experiment_Label_Index_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V003__Create_Experiment_Label_Index_table.cql
@@ -1,6 +1,6 @@
 -- Query: Get the experiment associated with an app/label locator
 
-create table experiment_label_index (
+create table if not exists experiment_label_index (
     app_name varchar,
     label varchar,
 
@@ -17,4 +17,4 @@ create table experiment_label_index (
 );
 
 -- Query: Get the experiment labels associated with an app
-create index on experiment_label_index(app_name);
+create index if not exists on experiment_label_index(app_name);

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V004__Create_State_Experiment_Index.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V004__Create_State_Experiment_Index.cql
@@ -1,6 +1,6 @@
 -- Query: Get the status of an experiment (deleted or not)
 
-create table state_experiment_index (
+create table if not exists state_experiment_index (
     index_key varchar,
     experiment_id uuid,
 

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V005__Create_UserAssignment_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V005__Create_UserAssignment_table.cql
@@ -1,6 +1,6 @@
 ---- Query: Get the assignment of a user to an experiment
 --THIS IS COMMENTED OUT BECAUSE WE ARE USING A NEWER VERSION
---create table user_assignment (
+--create table if not exists user_assignment (
 --    experiment_id uuid,
 --    user_id varchar,
 --
@@ -10,7 +10,7 @@
 --    PRIMARY KEY ((experiment_id, user_id))
 --);
 
-create table user_assignment (
+create table if not exists user_assignment (
     experiment_id uuid,
     user_id varchar,
     context varchar,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V006__Create_User_Experiment_Index_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V006__Create_User_Experiment_Index_table.cql
@@ -1,6 +1,6 @@
 -- Query: Get the list of experiments to which an app/user has been assigned
 --
---create table user_experiment_index (
+--create table if not exists user_experiment_index (
 --    app_name varchar,
 --    user_id varchar,
 --    experiment_id uuid,
@@ -11,7 +11,7 @@
 --)
 --with compact storage;
 
-create table user_experiment_index (
+create table if not exists user_experiment_index (
     app_name varchar,
     user_id varchar,
     context varchar,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V007__Create_User_Bucket_Index_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V007__Create_User_Bucket_Index_table.cql
@@ -1,7 +1,7 @@
 -- Query: Get the list of users assigned to a bucket
 --commented out for migration to context flg
 
---create table user_bucket_index (
+--create table if not exists user_bucket_index (
 --    experiment_id uuid,
 --    bucket_label varchar,
 --    user_id varchar,
@@ -12,7 +12,7 @@
 --)
 --with compact storage;
 
-create table user_bucket_index (
+create table if not exists user_bucket_index (
     experiment_id uuid,
     bucket_label varchar,
     user_id varchar,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V008__Create_Experiment_audit_log.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V008__Create_Experiment_audit_log.cql
@@ -1,4 +1,4 @@
-CREATE TABLE experiment_audit_log (
+CREATE TABLE IF NOT EXISTS experiment_audit_log (
   experiment_id uuid,
   modified timestamp,
   attribute_name text,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V009__Create_Bucket_audit_log.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V009__Create_Bucket_audit_log.cql
@@ -1,4 +1,4 @@
-CREATE TABLE bucket_audit_log (
+CREATE TABLE IF NOT EXISTS bucket_audit_log (
   experiment_id uuid,
   label text,
   modified timestamp,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V010__Create_Exclusion_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V010__Create_Exclusion_table.cql
@@ -1,6 +1,6 @@
 -- Create exclusions table to store metadata for mutual exclusion information
 
-CREATE TABLE exclusion (
+CREATE TABLE IF NOT EXISTS exclusion (
   base uuid,
   pair uuid,
   PRIMARY KEY (base, pair)

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V011__Create_Experiment_user_index.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V011__Create_Experiment_user_index.cql
@@ -1,6 +1,6 @@
 ---- Query: Get the list of experiments to which an app/user has been assigned
 --
---create table experiment_user_index (
+--create table if not exists experiment_user_index (
 --    user_id varchar,
 --    app_name varchar,
 --    bucket varchar,
@@ -11,7 +11,7 @@
 --)
 --;
 
-create table experiment_user_index (
+create table if not exists experiment_user_index (
     user_id varchar,
     context varchar,
     app_name varchar,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V012__Create_Application_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V012__Create_Application_table.cql
@@ -1,6 +1,6 @@
 -- Create priority table to store priority list for priority api
 
-CREATE TABLE application (
+CREATE TABLE IF NOT EXISTS application (
 
   app_name varchar,
   priorities list<uuid>,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V013__Create_Page_Experiment_Index_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V013__Create_Page_Experiment_Index_table.cql
@@ -1,4 +1,4 @@
-CREATE TABLE page_experiment_index (
+CREATE TABLE IF NOT EXISTS page_experiment_index (
   app_name text,
   page text,
   exp_id uuid,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V014__Create_Experiment_Page_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V014__Create_Experiment_Page_table.cql
@@ -1,4 +1,4 @@
-CREATE TABLE experiment_page (
+CREATE TABLE IF NOT EXISTS experiment_page (
   exp_id uuid,
   page text,
   assign boolean,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V015__Create_App_Page_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V015__Create_App_Page_table.cql
@@ -1,4 +1,4 @@
-CREATE TABLE app_page_index (
+CREATE TABLE IF NOT EXISTS app_page_index (
   app_name text,
   page text,
   PRIMARY KEY (app_name, page)

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V016__Create_User_Role_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V016__Create_User_Role_table.cql
@@ -1,4 +1,4 @@
-CREATE TABLE user_roles (
+CREATE TABLE IF NOT EXISTS user_roles (
   user_id text,
   app_name text,
   role text,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V017__Create_App_Role_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V017__Create_App_Role_table.cql
@@ -1,4 +1,4 @@
-CREATE TABLE app_roles (
+CREATE TABLE IF NOT EXISTS app_roles (
   app_name text,
   user_id text,
   role text,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V018__Create_Superadmins_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V018__Create_Superadmins_table.cql
@@ -1,4 +1,4 @@
-CREATE TABLE superadmins (
+CREATE TABLE IF NOT EXISTS superadmins (
   user_id text,
   PRIMARY KEY (user_id)
 );

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V019__Create_User_Info_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V019__Create_User_Info_table.cql
@@ -1,4 +1,4 @@
-CREATE TABLE user_info (
+CREATE TABLE IF NOT EXISTS user_info (
   user_id text,
   user_email text,
   firstname text,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V020__Create_User_Feedback_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V020__Create_User_Feedback_table.cql
@@ -1,4 +1,4 @@
-CREATE TABLE user_feedback (
+CREATE TABLE IF NOT EXISTS user_feedback (
   user_id text,
   submitted timestamp,
   score int,
@@ -9,7 +9,7 @@ CREATE TABLE user_feedback (
   PRIMARY KEY (user_id, submitted)
 );
 
-create index on user_feedback(user_email);
-create index on user_feedback(contact_okay);
+create index if not exists on user_feedback(user_email);
+create index if not exists on user_feedback(contact_okay);
 
 

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V021__Create_Staging_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V021__Create_Staging_table.cql
@@ -1,6 +1,7 @@
-create table staging(
-time timeuuid,
-type text,
-msg text,
-exep text,
-primary key(time));
+create table if not exists staging(
+  time timeuuid,
+  type text,
+  msg text,
+  exep text,
+  primary key(time)
+);

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V022__Create_Bucket_Assignment_Counts_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V022__Create_Bucket_Assignment_Counts_table.cql
@@ -1,4 +1,4 @@
-CREATE TABLE bucket_assignment_counts
+CREATE TABLE IF NOT EXISTS bucket_assignment_counts
   (experiment_id uuid,
    bucket_label varchar,
    bucket_assignment_count counter,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V023__Create_Auditlog_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V023__Create_Auditlog_table.cql
@@ -17,7 +17,7 @@
 --
 
 -- 'original' AuditLog table
-CREATE TABLE auditlog (
+CREATE TABLE IF NOT EXISTS auditlog (
     time             timestamp,
     event_id         uuid,
     action           varchar,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V024__Create_User_Assignment_Look_Up_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V024__Create_User_Assignment_Look_Up_table.cql
@@ -1,4 +1,4 @@
-create table user_assignment_look_up(
+create table if not exists user_assignment_look_up(
   experiment_id uuid,
   user_id varchar,
   context varchar,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V025__Create_User_Assignment_Export_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V025__Create_User_Assignment_Export_table.cql
@@ -1,4 +1,4 @@
-create table user_assignment_export(
+create table if not exists user_assignment_export(
   experiment_id uuid,
   user_id varchar,
   context varchar,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V027__Create_ApplicationList_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V027__Create_ApplicationList_table.cql
@@ -1,7 +1,7 @@
 -- Create applicationList table for top level applications.
 -- This cannot be deleted even when experiments are deleted.
 
-CREATE TABLE applicationList (
+CREATE TABLE IF NOT EXISTS applicationList (
   app_name varchar,
   PRIMARY KEY (app_name)
 );

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V029__Create_User_Assignment_By_UserId_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V029__Create_User_Assignment_By_UserId_table.cql
@@ -1,4 +1,4 @@
-create table user_assignment_by_userid (
+create table if not exists user_assignment_by_userid (
   experiment_id uuid,
   user_id varchar,
   context varchar,

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V035__Create_ExperimentTag_table.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V035__Create_ExperimentTag_table.cql
@@ -1,4 +1,4 @@
-create table experiment_tag (
+create table if not exists experiment_tag (
   app_name text,
   exp_id uuid,
   tags set<text>,


### PR DESCRIPTION
Changes the Cassandra migrations scripts to not create column families and indexes that already exist. This will allow the migrations scripts to be applied to existing wasabi deployments in a non-destructive manner.