### PR TITLE
Update databases with missing fields

### DIFF
--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V037__Alter_Experiment_Add_Source_Url.cql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/cassandra/migration/V037__Alter_Experiment_Add_Source_Url.cql
@@ -1,0 +1,2 @@
+alter table experiment ADD source_url text;
+alter table experiment ADD experiment_type text;

--- a/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V015__Alter_Experiment.sql
+++ b/modules/repository-datastax/src/main/resources/com/intuit/wasabi/repository/impl/mysql/migration/V015__Alter_Experiment.sql
@@ -1,0 +1,2 @@
+alter table experiment add source_url varchar(4096);
+alter table experiment add experiment_type varchar(200);


### PR DESCRIPTION
Following Issue #265 and #335, missing fields were added in Cassandra and sql.

