### PR TITLE
Modify README to reflect reality: this is not enterprise-grade sofware

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Project
 
-Wasabi A/B Testing Service is a real-time, enterprise-grade, 100% API driven project. Users are empowered to own their own data, and run experiments across web, mobile, and desktop. It’s fast, easy to use, it’s chock full of features, and instrumentation is minimal.
+Wasabi A/B Testing Service is a real-time, 100% API driven project. Users are empowered to own their own data, and run experiments across web, mobile, and desktop. It’s fast, easy to use, it’s chock full of features, and instrumentation is minimal.
 
 Learn more about how Wasabi can empower your team to move from hunches to actionable, data-driven user insights with our simple, flexible, and scalable experimentation platform.
 


### PR DESCRIPTION
Judging from the lack of maintainer support around MANY open issues about not being able to start the server, with the only guidance being a community user suggestion to revert to a 6-month old commit, it might be wise to set user expectations more realistically by removing the "enterprise-grade" qualifier in the README and elsewhere.