### PR TITLE
Grunt config to respect the entire default_constants.json

### DIFF
--- a/modules/ui/Gruntfile.js
+++ b/modules/ui/Gruntfile.js
@@ -542,6 +542,10 @@ module.exports = function (grunt) {
             distConstants['apiHostBaseUrlValue'] = process.env.API_HOST || defaultConstants['apiHostBaseUrlValue'];
             distConstants['downloadBaseUrlValue'] = process.env.API_HOST || defaultConstants['downloadBaseUrlValue'];
             distConstants['defaultBaseUrlValue'] = process.env.API_HOST || defaultConstants['defaultBaseUrlValue'];
+            distConstants['authnType'] = process.env.AUTHN_TYPE || defaultConstants['authnType'];
+            distConstants['noAuthRedirect'] = process.env.NO_AUTH_REDIRECT || defaultConstants['noAuthRedirect'];
+            distConstants['ssoLogoutRedirect'] = process.env.SSO_LOGOUT_REDIRECT || defaultConstants['ssoLogoutRedirect'];
+            distConstants['apiAuthInfo'] = process.env.API_AUTH_INFO || defaultConstants['apiAuthInfo'];
             grunt.file.write("build/constants.json", JSON.stringify(distConstants, null, 2));
         }
     });


### PR DESCRIPTION
The purpose of this change is to make it so that Gruntfile respect all the values in `default_constants.json`.

The current Gruntfile only respect some of the values in default_constants (the API_HOST ones). Supporting other values in the file (mostly SSO related) will be helpful with SSO integration.  