### PR TITLE
Fix flaky tests in AssignmentTest

### DIFF
--- a/modules/assignment-objects/src/main/java/com/intuit/wasabi/assignmentobjects/Assignment.java
+++ b/modules/assignment-objects/src/main/java/com/intuit/wasabi/assignmentobjects/Assignment.java
@@ -242,7 +242,18 @@ public class Assignment {
 
     @Override
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
+        return new HashCodeBuilder().append(this.getUserID())
+                .append(this.getBucketLabel())
+                .append(this.getStatus())
+                .append(this.getContext())
+                .append(this.isCacheable())
+                .append(this.getExperimentID())
+                .append(this.getContext())
+                .append(this.getApplicationName())
+                .append(this.isBucketEmpty())
+                .append(this.getExperimentLabel())
+                .append(this.getPayload())
+                .toHashCode();
     }
 
     @Override


### PR DESCRIPTION
### Description
Fix for 4 flaky tests which were found in class com.intuit.wasabi.assignmentobjects.AssignmentTest. The tests are as follows:  
- testAssignmentFromOther
- testAssignmentWithEmptyBucketAndDefaultNotEqualsAndHash
- testAssignmentWithEmptyBucketNotEqualsAndHash
- testAssignmentWithEmptyBucketEqualsAndHash

### Steps to reproduce
This was identified by running [NonDex](https://github.com/TestingResearchIllinois/NonDex). 
The flaky tests can be found when running the following command:
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest={test}

### Logs 
`Failed tests:   testAssignmentFromOther(com.intuit.wasabi.assignmentobjects.AssignmentTest): expected:<-1303240598> but was:<169444110>
  testAssignmentWithEmptyBucketAndDefaultNotEqualsAndHash(com.intuit.wasabi.assignmentobjects.AssignmentTest)
  testAssignmentWithEmptyBucketNotEqualsAndHash(com.intuit.wasabi.assignmentobjects.AssignmentTest)
  testAssignmentWithEmptyBucketEqualsAndHash(com.intuit.wasabi.assignmentobjects.AssignmentTest): expected:<1508589707> but was:<-992211973>
`

### Reason for failure 
The flaky nature of the test case is due to the `HashCodeBuilder.reflectionHashCode()` function. The function internally uses [getDeclaredFields()](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--) method which does not maintain the order in which the fields are fetched.

### Expected Behaviour
The hashCode() method should return same value for same objects irrespective of the fields order. 

### Actual Behaviour
The test is failing since it is returning different hashcode values 

### Solution
In order to fix this, we are now defining a fixed order in which the fields get appended in hashCode()  method.
