### PR TITLE
Fix Flaky Tests

### DIFF
--- a/modules/authentication-objects/src/main/java/com/intuit/wasabi/authenticationobjects/LoginCredentials.java
+++ b/modules/authentication-objects/src/main/java/com/intuit/wasabi/authenticationobjects/LoginCredentials.java
@@ -90,7 +90,10 @@ public class LoginCredentials {
 
     @Override
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
+        return new HashCodeBuilder().append(this.getUsername())
+                .append(this.getPassword())
+                .append(this.getNamespaceId())
+                .toHashCode();
     }
 
     @Override

--- a/modules/authorization-objects/src/main/java/com/intuit/wasabi/authorizationobjects/UserRole.java
+++ b/modules/authorization-objects/src/main/java/com/intuit/wasabi/authorizationobjects/UserRole.java
@@ -147,7 +147,13 @@ public class UserRole {
 
     @Override
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
+        return new HashCodeBuilder().append(this.getApplicationName())
+                .append(this.getRole())
+                .append(this.getUserID())
+                .append(this.getUserEmail())
+                .append(this.getFirstName())
+                .append(this.getLastName())
+                .toHashCode();
     }
 
     @Override


### PR DESCRIPTION
### Description

Identified and fixed two flaky tests: 
1. com.intuit.wasabi.authorizationobjects.UserRoleTest.testAssignmentFromOther
2. com.intuit.wasabi.authenticationobjects.LoginCredentialsTest.testHashCodeAndEquals

### Steps to reproduce 

Run the test multiple times. The current hashCode() logic in both classes used the HashCodeBuilder.reflectionHashCode() function. The function internally uses [getDeclaredFields()](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--) method which does not maintain the order in which the fields are fetched. 

Instead, a HashCodeBuilder was manually created and fields were appended in a fixed order to avoid any test failures due to field order.

This was identified by running [NonDex](https://github.com/TestingResearchIllinois/NonDex).
The flaky tests can be found when running the following command:
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest={test}


### Expected Behaviour
The hash code for an object should not depend on the order of fields in the class.

### Actual Behaviour
The tests were failing since the hash code function was dependent on the order of fields returned by the HashCodeBuilder.reflectionHashCode() method which can change any time.

### Solution

An updated hashCode() method which does not depend on the order of fields was pushed.