### PR TITLE
Fix flaky tests across multiple classes

### DIFF
--- a/modules/analytics-objects/src/main/java/com/intuit/wasabi/analyticsobjects/Event.java
+++ b/modules/analytics-objects/src/main/java/com/intuit/wasabi/analyticsobjects/Event.java
@@ -113,7 +113,13 @@ public class Event implements Cloneable {
 
     @Override
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
+        return new HashCodeBuilder().append(timestamp)
+                .append(type)
+                .append(name)
+                .append(context)
+                .append(payload)
+                .append(value)
+                .toHashCode();
     }
 
     @Override

--- a/modules/analytics-objects/src/main/java/com/intuit/wasabi/analyticsobjects/statistics/Estimate.java
+++ b/modules/analytics-objects/src/main/java/com/intuit/wasabi/analyticsobjects/statistics/Estimate.java
@@ -82,7 +82,10 @@ public class Estimate implements Cloneable {
 
     @Override
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
+        return new HashCodeBuilder().append(estimate)
+                .append(upperBound)
+                .append(lowerBound)
+                .toHashCode();
     }
 
     @Override

--- a/modules/analytics-objects/src/test/java/com/intuit/wasabi/analyticsobjects/EventTest.java
+++ b/modules/analytics-objects/src/test/java/com/intuit/wasabi/analyticsobjects/EventTest.java
@@ -106,7 +106,7 @@ public class EventTest {
     @Test
     public void testHashCode() {
         Event event = new Event();
-        assertThat(event.hashCode(), is(-1985862199));
+        assertThat(event.hashCode(), is(-252394171));
         assertThat(event.toString(), containsString("Event"));
     }
 }

--- a/modules/authentication-objects/src/main/java/com/intuit/wasabi/authenticationobjects/LoginCredentials.java
+++ b/modules/authentication-objects/src/main/java/com/intuit/wasabi/authenticationobjects/LoginCredentials.java
@@ -90,7 +90,7 @@ public class LoginCredentials {
 
     @Override
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
+        return new HashCodeBuilder().append(username).append(namespaceId).toHashCode();
     }
 
     @Override

--- a/modules/authentication-objects/src/main/java/com/intuit/wasabi/authenticationobjects/LoginToken.java
+++ b/modules/authentication-objects/src/main/java/com/intuit/wasabi/authenticationobjects/LoginToken.java
@@ -85,7 +85,10 @@ public class LoginToken {
 
     @Override
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
+        return new HashCodeBuilder()
+                .append(token_type)
+                .append(access_token)
+                .toHashCode();
     }
 
     @Override

--- a/modules/experiment-objects/src/main/java/com/intuit/wasabi/experimentobjects/PageExperiment.java
+++ b/modules/experiment-objects/src/main/java/com/intuit/wasabi/experimentobjects/PageExperiment.java
@@ -104,7 +104,7 @@ public class PageExperiment implements Cloneable, Serializable {
 
     @Override
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
+        return new HashCodeBuilder().append(id).append(label).append(allowNewAssignment).toHashCode();
     }
 
     @Override


### PR DESCRIPTION
### Description
Fix for 5 flaky tests which were found in multiple classes. The tests are as follows:  
- com.intuit.wasabi.analyticsobjects.statistics.EstimateTest#testBuilder
- com.intuit.wasabi.analyticsobjects.EventTest#testHashCode
- com.intuit.wasabi.authenticationobjects.LoginTokenTest#testAssignmentFromOther
- com.intuit.wasabi.authenticationobjects.LoginCredentialsTest#testHashCodeAndEquals
- com.intuit.wasabi.experimentobjects.PageExperimentTest#testHashCode

### Steps to reproduce
This was identified by running [NonDex](https://github.com/TestingResearchIllinois/NonDex). 
The flaky tests can be found when running the following command:
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest={test}

### Failure 
<img width="917" alt="Screenshot 2024-10-22 at 8 10 07 PM" src="https://github.com/user-attachments/assets/ecfc7b4c-af08-4cd1-8dbf-cd60cc7f01c9">



### Reason for failure 
The flaky nature of the test case is due to the `HashCodeBuilder.reflectionHashCode()` function. The function internally uses [getDeclaredFields()](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--) method which does not maintain the order in which the fields are fetched.

### Expected Behaviour
The hashCode() method should return same value for same objects irrespective of the fields order. 

### Actual Behaviour
The test is failing since it is returning different hashcode values 

### Solution
In order to fix this, we are now defining a fixed order in which the fields get appended in hashCode()  method.
